### PR TITLE
Add company categories for filtering

### DIFF
--- a/app/Http/Controllers/CompanyController.php
+++ b/app/Http/Controllers/CompanyController.php
@@ -34,6 +34,10 @@ class CompanyController extends Controller
             $query->where('country', $country);
         }
 
+        if ($category = $request->get('category')) {
+            $query->where('category', $category);
+        }
+
         // Date range filter for last fundraise
         if ($fundedAfter = $request->get('funded_after')) {
             $query->whereHas('fundingRounds', function ($q) use ($fundedAfter) {
@@ -66,15 +70,16 @@ class CompanyController extends Controller
         $sortField = $request->get('sort', 'name');
         $sortDirection = $request->get('direction', 'asc');
 
-        $allowedSorts = ['name', 'founded_date', 'city', 'country', 'funding_rounds_sum_amount', 'latest_funding_date'];
+        $allowedSorts = ['name', 'founded_date', 'city', 'country', 'category', 'funding_rounds_sum_amount', 'latest_funding_date'];
         if (in_array($sortField, $allowedSorts)) {
             $query->orderBy($sortField, $sortDirection === 'desc' ? 'desc' : 'asc');
         }
 
         $companies = $query->paginate(50)->withQueryString();
         $countries = Company::distinct()->pluck('country')->filter()->sort()->values();
+        $categories = Company::CATEGORIES;
 
-        return view('companies.index', compact('companies', 'countries'));
+        return view('companies.index', compact('companies', 'countries', 'categories'));
     }
 
     public function show(Company $company)

--- a/app/Models/Company.php
+++ b/app/Models/Company.php
@@ -9,6 +9,19 @@ use Illuminate\Database\Eloquent\Relations\HasOne;
 
 class Company extends Model
 {
+    public const CATEGORIES = [
+        'ai_ml' => 'AI/ML',
+        'fintech' => 'Fintech',
+        'enterprise' => 'Enterprise',
+        'healthcare' => 'Healthcare',
+        'robotics' => 'Robotics',
+        'space' => 'Space',
+        'climate' => 'Climate/Energy',
+        'consumer' => 'Consumer',
+        'developer_tools' => 'Developer Tools',
+        'defense' => 'Defense',
+    ];
+
     protected $fillable = [
         'name',
         'slug',
@@ -19,6 +32,7 @@ class Company extends Model
         'city',
         'state',
         'country',
+        'category',
         'linkedin_url',
         'current_headcount',
         'profile_refreshed_at',
@@ -68,5 +82,10 @@ class Company extends Model
     public function getRouteKeyName(): string
     {
         return 'slug';
+    }
+
+    public function getCategoryLabelAttribute(): ?string
+    {
+        return $this->category ? (self::CATEGORIES[$this->category] ?? $this->category) : null;
     }
 }

--- a/database/migrations/2026_01_03_133026_add_category_to_companies_table.php
+++ b/database/migrations/2026_01_03_133026_add_category_to_companies_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('companies', function (Blueprint $table) {
+            $table->string('category')->nullable()->after('country');
+            $table->index('category');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('companies', function (Blueprint $table) {
+            $table->dropIndex(['category']);
+            $table->dropColumn('category');
+        });
+    }
+};

--- a/database/seeders/CompanyCategorySeeder.php
+++ b/database/seeders/CompanyCategorySeeder.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Company;
+use Illuminate\Database\Seeder;
+
+class CompanyCategorySeeder extends Seeder
+{
+    /**
+     * Assign categories to all existing companies.
+     */
+    public function run(): void
+    {
+        $categories = [
+            'ai_ml' => [
+                'OpenAI', 'Anthropic', 'xAI', 'Cohere', 'Mistral AI', 'Hugging Face',
+                'Scale AI', 'Weights & Biases', 'Groq', 'Together AI', 'Character.AI',
+                'Inflection AI', 'Stability AI', 'Midjourney', 'Runway', 'Jasper',
+                'Copy.ai', 'Writer', 'Glean', 'Perplexity', 'Cursor', 'Applied Intuition',
+                'ElevenLabs', 'Mercor', 'Lovable', 'Imbue', 'Covariant', 'Poolside',
+                'Magic', 'Cognition', 'Anysphere', 'Adept', 'Harvey', 'Synthesia',
+                'Mosaic ML', 'Anyscale', 'Cerebras Systems', 'NeoLogic',
+            ],
+            'fintech' => [
+                'Stripe', 'Plaid', 'Chime', 'Brex', 'Ramp', 'Mercury', 'Klarna',
+                'Affirm', 'Checkout.com', 'Revolut', 'Wise', 'Marqeta', 'Robinhood',
+                'Coinbase', 'Rippling', 'Deel', 'Pine Labs', 'Karat Financial', 'Zip',
+                'Alpaca', 'Synctera', 'Djamo', 'Sardine', 'Gusto',
+            ],
+            'enterprise' => [
+                'Databricks', 'ServiceTitan', 'Toast', 'Celonis', 'Monday.com',
+                'Asana', 'Notion', 'Airtable', 'ClickUp', 'Miro', 'Figma', 'Canva',
+                'Webflow', 'Loom', 'Linear', 'Calendly', 'Island', 'SecurityPal',
+                'Wiz', 'Vanta', 'Flock Safety', 'Navan', 'Retool', 'Faire',
+            ],
+            'healthcare' => [
+                'Devoted Health', 'Ro', 'Hims & Hers', 'Noom', 'Tempus', 'Headspace',
+                'Calm', 'Retro Biosciences', 'Mammoth Biosciences', 'Cradle',
+                'Cortical Labs', 'Ginkgo Bioworks',
+            ],
+            'robotics' => [
+                'Figure AI', '1X Technologies', 'Pickle Robot', 'Coco',
+                'Diligent Robotics', 'Chef Robotics', 'Apptronik', 'Agility Robotics',
+                'Nuro', 'Waymo', 'Cruise', 'Aurora',
+            ],
+            'space' => [
+                'SpaceX', 'Blue Origin', 'Relativity Space', 'Stoke Space', 'Vast',
+                'Intuitive Machines', 'Orbit Fab', 'ABL Space Systems', 'Gravitics',
+            ],
+            'climate' => [
+                'Redwood Materials', 'Amp Robotics', 'Gridware', 'Lumotive', 'Rivian',
+            ],
+            'consumer' => [
+                'Airbnb', 'DoorDash', 'Instacart', 'Reddit', 'Dropbox', 'Twitch',
+                'Poshmark', 'StockX', 'Goat', 'Whatnot', 'Fanatics', 'Bird',
+                'Bluesky', 'Fizz', 'Shipt', 'ByteDance',
+            ],
+            'developer_tools' => [
+                'Vercel', 'Replit', 'Postman', 'GitLab', 'HashiCorp', 'Snyk',
+                'LaunchDarkly', 'PagerDuty', 'Datadog', 'Grafana Labs', 'Amplitude',
+                'Benchling', 'UiPath', 'Zapier', 'Supabase', 'Plural', 'Parasail',
+                'Flexport',
+            ],
+            'defense' => [
+                'Anduril Industries', 'Castelion',
+            ],
+        ];
+
+        $updated = 0;
+
+        foreach ($categories as $category => $companyNames) {
+            foreach ($companyNames as $name) {
+                $count = Company::where('name', $name)
+                    ->whereNull('category')
+                    ->update(['category' => $category]);
+                $updated += $count;
+            }
+        }
+
+        $this->command->info("Updated {$updated} companies with categories.");
+
+        // Report any uncategorized companies
+        $uncategorized = Company::whereNull('category')->pluck('name');
+        if ($uncategorized->isNotEmpty()) {
+            $this->command->warn("Uncategorized companies: " . $uncategorized->join(', '));
+        }
+    }
+}

--- a/database/seeders/TechCrunchCompaniesSeeder.php
+++ b/database/seeders/TechCrunchCompaniesSeeder.php
@@ -10,6 +10,9 @@ class TechCrunchCompaniesSeeder extends Seeder
     /**
      * Companies sourced from TechCrunch headlines (Dec 2025 - Jan 2026).
      * Excludes companies already in the database.
+     *
+     * IMPORTANT: When adding new companies, always include the 'category' field.
+     * Valid categories: ai_ml, fintech, enterprise, healthcare, robotics, space, climate, consumer, developer_tools, defense
      */
     public function run(): void
     {
@@ -17,6 +20,7 @@ class TechCrunchCompaniesSeeder extends Seeder
             // AI/ML Companies
             [
                 'name' => 'Applied Intuition',
+                'category' => 'ai_ml',
                 'slug' => 'applied-intuition',
                 'website' => 'https://www.appliedintuition.com',
                 'linkedin_url' => 'https://www.linkedin.com/company/applied-intuition',

--- a/resources/views/companies/index.blade.php
+++ b/resources/views/companies/index.blade.php
@@ -24,6 +24,19 @@
             </div>
             <div class="sm:w-48">
                 <select
+                    name="category"
+                    class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                >
+                    <option value="">All Categories</option>
+                    @foreach($categories as $key => $label)
+                        <option value="{{ $key }}" {{ request('category') == $key ? 'selected' : '' }}>
+                            {{ $label }}
+                        </option>
+                    @endforeach
+                </select>
+            </div>
+            <div class="sm:w-48">
+                <select
                     name="country"
                     class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
                 >
@@ -53,7 +66,7 @@
             >
                 Filter
             </button>
-            @if(request()->hasAny(['search', 'country', 'funded_recent', 'funded_after', 'funded_before']))
+            @if(request()->hasAny(['search', 'category', 'country', 'funded_recent', 'funded_after', 'funded_before']))
                 <a
                     href="{{ route('companies.index') }}"
                     class="px-6 py-2 bg-gray-200 text-gray-700 rounded-lg hover:bg-gray-300 transition-colors text-center"
@@ -73,6 +86,14 @@
                             <a href="{{ request()->fullUrlWithQuery(['sort' => 'name', 'direction' => request('sort') === 'name' && request('direction') !== 'desc' ? 'desc' : 'asc']) }}" class="hover:text-gray-700">
                                 Company
                                 @if(request('sort', 'name') === 'name')
+                                    <span class="ml-1">{{ request('direction') === 'desc' ? '↓' : '↑' }}</span>
+                                @endif
+                            </a>
+                        </th>
+                        <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                            <a href="{{ request()->fullUrlWithQuery(['sort' => 'category', 'direction' => request('sort') === 'category' && request('direction') !== 'desc' ? 'desc' : 'asc']) }}" class="hover:text-gray-700">
+                                Category
+                                @if(request('sort') === 'category')
                                     <span class="ml-1">{{ request('direction') === 'desc' ? '↓' : '↑' }}</span>
                                 @endif
                             </a>
@@ -125,6 +146,15 @@
                                     {{ $company->name }}
                                 </a>
                             </td>
+                            <td class="px-6 py-4 whitespace-nowrap text-sm">
+                                @if($company->category)
+                                    <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800">
+                                        {{ $company->category_label }}
+                                    </span>
+                                @else
+                                    <span class="text-gray-400">—</span>
+                                @endif
+                            </td>
                             <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
                                 {{ collect([$company->city, $company->country])->filter()->join(', ') ?: '—' }}
                             </td>
@@ -170,7 +200,7 @@
                         </tr>
                     @empty
                         <tr>
-                            <td colspan="7" class="px-6 py-12 text-center text-gray-500">
+                            <td colspan="8" class="px-6 py-12 text-center text-gray-500">
                                 No companies found matching your criteria.
                             </td>
                         </tr>


### PR DESCRIPTION
## Summary

- Add `category` column to companies table for filtering
- Add category dropdown filter to the companies list
- Add sortable Category column with badge display
- Categorize all 161 existing companies

## Categories

| Category | Count |
|----------|-------|
| AI/ML | 39 |
| Enterprise | 24 |
| Fintech | 24 |
| Developer Tools | 18 |
| Consumer | 16 |
| Healthcare | 12 |
| Robotics | 12 |
| Space | 9 |
| Climate/Energy | 5 |
| Defense | 2 |

## Screenshots

The table now shows a Category column with colored badges, and users can filter by category using the dropdown.

## Process for adding new companies

When adding new companies via seeders, include the `category` field:
```php
[
    'name' => 'New Company',
    'category' => 'ai_ml',  // Required!
    // ... other fields
]
```

Valid categories are defined in `Company::CATEGORIES`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)