### PR TITLE
Add growth visualizations to company pages

### DIFF
--- a/resources/views/companies/show.blade.php
+++ b/resources/views/companies/show.blade.php
@@ -93,7 +93,7 @@
                     @else
                         <div class="flex items-center justify-between p-4 bg-gray-50 rounded-lg">
                             <span class="text-gray-600">Current</span>
-                            <span class="font-semibold text-gray-900">{{ number_format($company->headcountSnapshots->first()->headcount) }} employees</span>
+                            <span class="font-semibold text-gray-900">{{ number_format($company->headcountSnapshots->first()?->headcount ?? 0) }} employees</span>
                         </div>
                         <p class="text-sm text-gray-500 mt-3">More data points needed to show growth chart.</p>
                     @endif
@@ -250,6 +250,14 @@
         return '$' + value.toLocaleString();
     }
 
+    // Sanitize text for display (defense in depth)
+    function sanitizeText(text) {
+        if (typeof text !== 'string') return '';
+        return text.replace(/[<>&"']/g, function(c) {
+            return {'<':'&lt;','>':'&gt;','&':'&amp;','"':'&quot;',"'":'&#39;'}[c];
+        });
+    }
+
     // Round type colors
     const roundColors = {
         'seed': { bg: 'rgba(34, 197, 94, 0.8)', border: 'rgb(34, 197, 94)' },
@@ -355,7 +363,7 @@
         if (rounds.length < 2) return;
 
         const labels = rounds.map(r => {
-            const type = r.round_type ? r.round_type.replace('_', ' ') : 'Round';
+            const type = r.round_type ? sanitizeText(r.round_type).replace('_', ' ') : 'Round';
             return type.charAt(0).toUpperCase() + type.slice(1);
         });
         const data = rounds.map(r => r.amount);


### PR DESCRIPTION
## Summary

- Added a **funding bar chart** that displays amount raised for each funding round, with color coding by round type (Seed=green, Series A-E=blue to purple gradient)
- Enhanced the **headcount line chart** with loading states, improved tooltips, and better UX
- Implemented **lazy loading** using Intersection Observer so charts only render when scrolled into view (doesn't block initial page render)
- Added loading spinner animation while charts initialize
- Enhanced tooltips with formatted currency values and dates
- Added hover effects on funding round list items for better interactivity

## Implementation Details

### Headcount Chart
- Line chart showing employee count over time
- Uses Chart.js with smooth bezier curves (`tension: 0.3`)
- Displays date (Mon Year) on X-axis, employee count on Y-axis
- Shows loading spinner until chart renders
- Gracefully handles < 2 data points by showing a simple display with message

### Funding Chart
- Bar chart showing funding rounds chronologically
- Color-coded by round type for easy visual identification
- Tooltips show round type, date, and formatted amount ($XXM or $X.XB)
- Only displays if company has 2+ funding rounds with known amounts
- Falls back to the existing list view if insufficient data

### Performance
- Charts are lazy loaded using Intersection Observer (100px rootMargin)
- Data is embedded as JSON in the page to avoid additional API calls
- Charts initialize when they enter the viewport (or are within 100px)
- Fallback for older browsers without IntersectionObserver support

## Test Plan

- [ ] View company WITH headcount data (2+ snapshots) - line chart renders
- [ ] View company with only 1 headcount snapshot - shows simple display with message
- [ ] View company WITHOUT headcount data - section not displayed
- [ ] View company with 2+ funding rounds - bar chart + list renders
- [ ] View company with 1 funding round - list only (no chart)
- [ ] Hover on headcount chart - tooltip shows "X employees" at date
- [ ] Hover on funding chart - tooltip shows round type, date, and $XXM
- [ ] Check mobile viewport - charts are responsive
- [ ] Page loads quickly (charts don't block initial render)
- [ ] Scroll charts into view - loading spinner then chart appears

## Assumptions

- Companies need at least 2 data points to show growth charts (otherwise simple display)
- Funding amounts of 0 or null are excluded from the bar chart
- Chart.js is already loaded in the project layout (via CDN)
- Round types follow the naming convention: seed, series_a, series_b, etc.

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)