### PR TITLE
Add public JSON API and MCP server for AI agent access

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The database currently includes **107 companies** with:
 
 ## Tech stack
 
-- Laravel 11
+- Laravel 12
 - SQLite (development) / MySQL/PostgreSQL (production)
 - Tailwind CSS
 - Blade templates
@@ -97,10 +97,85 @@ Early development. See [Issue #1](https://github.com/dmorrill/startupgraph/issue
 - [#3](https://github.com/dmorrill/startupgraph/issues/3) - Backfill source URLs for funding rounds
 - [#4](https://github.com/dmorrill/startupgraph/issues/4) - Add recurring job to refresh company data
 
+## API
+
+StartupGraph provides a public JSON API with no authentication required. Designed to be queried by AI agents like Claude Code.
+
+### Endpoints
+
+| Endpoint | Description |
+|----------|-------------|
+| `GET /api/stats` | Database statistics |
+| `GET /api/search?q=` | Search companies and people |
+| `GET /api/companies` | List companies with filters |
+| `GET /api/companies/{slug}` | Full company profile |
+| `GET /api/companies/{slug}/funding` | Funding history |
+| `GET /api/companies/{slug}/people` | Leadership team |
+| `GET /api/companies/{slug}/headcount` | Employee growth |
+| `GET /api/people/{slug}` | Person profile |
+| `GET /api/categories` | List category filters |
+
+### Query Parameters
+
+For `/api/companies`:
+- `q` - Search by name, description, city, country
+- `category` - Filter by category (ai_ml, fintech, enterprise, etc.)
+- `country` - Filter by country
+- `funded_after` - Date filter (YYYY-MM-DD)
+- `funded_before` - Date filter (YYYY-MM-DD)
+- `funded_recent` - Preset filter (3m, 6m, 1y, 2y)
+- `sort` - Sort field (name, founded_date, funding_rounds_sum_amount, etc.)
+- `order` - Sort direction (asc, desc)
+- `per_page` - Results per page (default 50, max 100)
+
+### Example
+
+```bash
+# Get all AI/ML companies
+curl "http://localhost:8000/api/companies?category=ai_ml"
+
+# Search for a company
+curl "http://localhost:8000/api/search?q=stripe"
+
+# Get full company profile
+curl "http://localhost:8000/api/companies/stripe"
+```
+
+## MCP Server
+
+Use StartupGraph directly from Claude Code with the MCP server:
+
+```bash
+# Add to Claude Code
+claude mcp add startupgraph -- npx @startupgraph/mcp
+
+# Or with custom API URL
+claude mcp add startupgraph -- npx @startupgraph/mcp --url http://localhost:8000/api
+```
+
+### Available Tools
+
+| Tool | Description |
+|------|-------------|
+| `search_companies` | Search for companies by name, industry, or location |
+| `get_company` | Get detailed traction data for a specific company |
+| `get_funding_history` | Get complete funding rounds with investors |
+| `get_leadership` | Get company executives and team |
+| `get_headcount_history` | Get employee count over time |
+| `compare_companies` | Compare 2-5 companies side-by-side |
+| `list_categories` | List available category filters |
+| `get_stats` | Get database statistics |
+
+Once installed, ask Claude Code questions like:
+- "What's Stripe's funding history?"
+- "Compare OpenAI and Anthropic"
+- "Find AI companies in San Francisco"
+
+See [mcp-server/README.md](mcp-server/README.md) for full documentation.
+
 ## Future plans
 
-- Public API
-- MCP server for AI tool integration
+- Hosted public API at startupgraph.dev
 - Community contributions to keep data fresh
 - Automated data refresh from company websites
 

--- a/app/Http/Controllers/Api/CompanyController.php
+++ b/app/Http/Controllers/Api/CompanyController.php
@@ -1,0 +1,219 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Resources\CompanyResource;
+use App\Http\Resources\CompanySummaryResource;
+use App\Http\Resources\FundingRoundResource;
+use App\Http\Resources\HeadcountSnapshotResource;
+use App\Http\Resources\PersonSummaryResource;
+use App\Models\Company;
+use App\Models\FundingRound;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Carbon;
+
+class CompanyController extends Controller
+{
+    public function index(Request $request): JsonResponse
+    {
+        $query = Company::query()
+            ->withSum('fundingRounds', 'amount')
+            ->withCount('fundingRounds')
+            ->with('latestFundingRound')
+            ->addSelect(['latest_funding_date' => FundingRound::select('announced_date')
+                ->whereColumn('company_id', 'companies.id')
+                ->orderBy('announced_date', 'desc')
+                ->limit(1)
+            ]);
+
+        // Search by name, description, city, country
+        if ($search = $request->get('q')) {
+            $query->where(function ($q) use ($search) {
+                $q->where('name', 'like', "%{$search}%")
+                  ->orWhere('description', 'like', "%{$search}%")
+                  ->orWhere('city', 'like', "%{$search}%")
+                  ->orWhere('country', 'like', "%{$search}%");
+            });
+        }
+
+        if ($country = $request->get('country')) {
+            $query->where('country', $country);
+        }
+
+        if ($category = $request->get('category')) {
+            $query->where('category', $category);
+        }
+
+        // Date range filter for last fundraise
+        if ($fundedAfter = $request->get('funded_after')) {
+            $query->whereHas('fundingRounds', function ($q) use ($fundedAfter) {
+                $q->where('announced_date', '>=', $fundedAfter);
+            });
+        }
+
+        if ($fundedBefore = $request->get('funded_before')) {
+            $query->whereHas('fundingRounds', function ($q) use ($fundedBefore) {
+                $q->where('announced_date', '<=', $fundedBefore);
+            });
+        }
+
+        // Preset date filters
+        if ($fundedRecent = $request->get('funded_recent')) {
+            $dateThreshold = match ($fundedRecent) {
+                '3m' => Carbon::now()->subMonths(3),
+                '6m' => Carbon::now()->subMonths(6),
+                '1y' => Carbon::now()->subYear(),
+                '2y' => Carbon::now()->subYears(2),
+                default => null,
+            };
+            if ($dateThreshold) {
+                $query->whereHas('fundingRounds', function ($q) use ($dateThreshold) {
+                    $q->where('announced_date', '>=', $dateThreshold);
+                });
+            }
+        }
+
+        $sortField = $request->get('sort', 'name');
+        $sortDirection = $request->get('order', 'asc');
+
+        $allowedSorts = ['name', 'founded_date', 'city', 'country', 'category', 'funding_rounds_sum_amount', 'latest_funding_date'];
+        if (in_array($sortField, $allowedSorts)) {
+            $query->orderBy($sortField, $sortDirection === 'desc' ? 'desc' : 'asc');
+        }
+
+        $perPage = min((int) $request->get('per_page', 50), 100);
+        $companies = $query->paginate($perPage);
+
+        return response()->json([
+            'data' => CompanySummaryResource::collection($companies),
+            'meta' => [
+                'source' => 'startupgraph',
+                'version' => '1.0',
+                'generated_at' => now()->toIso8601String(),
+            ],
+            'pagination' => [
+                'total' => $companies->total(),
+                'per_page' => $companies->perPage(),
+                'current_page' => $companies->currentPage(),
+                'last_page' => $companies->lastPage(),
+            ],
+        ]);
+    }
+
+    public function show(Company $company): JsonResponse
+    {
+        $company->load([
+            'fundingRounds.investors',
+            'latestFundingRound',
+            'headcountSnapshots',
+            'people',
+        ]);
+
+        $company->loadSum('fundingRounds', 'amount');
+        $company->loadCount('fundingRounds');
+
+        return response()->json([
+            'data' => new CompanyResource($company),
+            'meta' => [
+                'source' => 'startupgraph',
+                'version' => '1.0',
+                'generated_at' => now()->toIso8601String(),
+            ],
+        ]);
+    }
+
+    public function funding(Company $company): JsonResponse
+    {
+        $company->load('fundingRounds.investors');
+
+        $fundingRounds = $company->fundingRounds->sortByDesc('announced_date')->values();
+
+        return response()->json([
+            'data' => [
+                'company_slug' => $company->slug,
+                'company_name' => $company->name,
+                'total_funding' => (float) $fundingRounds->sum('amount'),
+                'total_funding_formatted' => $this->formatAmount($fundingRounds->sum('amount')),
+                'rounds_count' => $fundingRounds->count(),
+                'funding_rounds' => FundingRoundResource::collection($fundingRounds),
+            ],
+            'meta' => [
+                'source' => 'startupgraph',
+                'version' => '1.0',
+                'generated_at' => now()->toIso8601String(),
+            ],
+        ]);
+    }
+
+    public function people(Company $company): JsonResponse
+    {
+        $company->load('people');
+
+        $currentPeople = $company->people->where('pivot.is_current', true)->values();
+        $formerPeople = $company->people->where('pivot.is_current', false)->values();
+
+        return response()->json([
+            'data' => [
+                'company_slug' => $company->slug,
+                'company_name' => $company->name,
+                'total_count' => $company->people->count(),
+                'current_count' => $currentPeople->count(),
+                'current' => PersonSummaryResource::collection($currentPeople),
+                'former' => PersonSummaryResource::collection($formerPeople),
+            ],
+            'meta' => [
+                'source' => 'startupgraph',
+                'version' => '1.0',
+                'generated_at' => now()->toIso8601String(),
+            ],
+        ]);
+    }
+
+    public function headcount(Company $company): JsonResponse
+    {
+        $company->load('headcountSnapshots');
+
+        $snapshots = $company->headcountSnapshots->sortBy('recorded_date')->values();
+
+        $growth = null;
+        if ($snapshots->count() >= 2) {
+            $first = $snapshots->first()->headcount;
+            $last = $snapshots->last()->headcount;
+            if ($first > 0) {
+                $growth = round((($last - $first) / $first) * 100, 1);
+            }
+        }
+
+        return response()->json([
+            'data' => [
+                'company_slug' => $company->slug,
+                'company_name' => $company->name,
+                'current_headcount' => $company->current_headcount,
+                'snapshots_count' => $snapshots->count(),
+                'growth_percent' => $growth,
+                'snapshots' => HeadcountSnapshotResource::collection($snapshots),
+            ],
+            'meta' => [
+                'source' => 'startupgraph',
+                'version' => '1.0',
+                'generated_at' => now()->toIso8601String(),
+            ],
+        ]);
+    }
+
+    private function formatAmount(float $amount): string
+    {
+        if ($amount >= 1_000_000_000) {
+            return '$' . number_format($amount / 1_000_000_000, 1) . 'B';
+        }
+        if ($amount >= 1_000_000) {
+            return '$' . number_format($amount / 1_000_000, 1) . 'M';
+        }
+        if ($amount >= 1_000) {
+            return '$' . number_format($amount / 1_000, 0) . 'K';
+        }
+        return '$' . number_format($amount, 0);
+    }
+}

--- a/app/Http/Controllers/Api/PersonController.php
+++ b/app/Http/Controllers/Api/PersonController.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Resources\PersonResource;
+use App\Models\Person;
+use Illuminate\Http\JsonResponse;
+
+class PersonController extends Controller
+{
+    public function show(Person $person): JsonResponse
+    {
+        $person->load('companies');
+
+        return response()->json([
+            'data' => new PersonResource($person),
+            'meta' => [
+                'source' => 'startupgraph',
+                'version' => '1.0',
+                'generated_at' => now()->toIso8601String(),
+            ],
+        ]);
+    }
+}

--- a/app/Http/Controllers/Api/SearchController.php
+++ b/app/Http/Controllers/Api/SearchController.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Resources\CompanySummaryResource;
+use App\Http\Resources\PersonSummaryResource;
+use App\Models\Company;
+use App\Models\FundingRound;
+use App\Models\Person;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class SearchController extends Controller
+{
+    public function index(Request $request): JsonResponse
+    {
+        $query = $request->get('q', '');
+        $limit = min((int) $request->get('limit', 10), 50);
+
+        if (strlen($query) < 2) {
+            return response()->json([
+                'data' => [
+                    'companies' => [],
+                    'people' => [],
+                ],
+                'meta' => [
+                    'source' => 'startupgraph',
+                    'version' => '1.0',
+                    'generated_at' => now()->toIso8601String(),
+                    'query' => $query,
+                    'message' => 'Query must be at least 2 characters',
+                ],
+            ]);
+        }
+
+        // Search companies
+        $companies = Company::query()
+            ->where(function ($q) use ($query) {
+                $q->where('name', 'like', "%{$query}%")
+                  ->orWhere('description', 'like', "%{$query}%")
+                  ->orWhere('city', 'like', "%{$query}%")
+                  ->orWhere('country', 'like', "%{$query}%");
+            })
+            ->withSum('fundingRounds', 'amount')
+            ->withCount('fundingRounds')
+            ->addSelect(['latest_funding_date' => FundingRound::select('announced_date')
+                ->whereColumn('company_id', 'companies.id')
+                ->orderBy('announced_date', 'desc')
+                ->limit(1)
+            ])
+            ->orderByRaw("CASE WHEN name LIKE ? THEN 0 ELSE 1 END", ["{$query}%"])
+            ->orderBy('name')
+            ->limit($limit)
+            ->get();
+
+        // Search people
+        $people = Person::query()
+            ->where(function ($q) use ($query) {
+                $q->where('name', 'like', "%{$query}%")
+                  ->orWhere('bio', 'like', "%{$query}%");
+            })
+            ->with(['companies' => fn ($q) => $q->wherePivot('is_current', true)->limit(1)])
+            ->orderByRaw("CASE WHEN name LIKE ? THEN 0 ELSE 1 END", ["{$query}%"])
+            ->orderBy('name')
+            ->limit($limit)
+            ->get();
+
+        return response()->json([
+            'data' => [
+                'companies' => CompanySummaryResource::collection($companies),
+                'people' => $people->map(fn ($person) => [
+                    'slug' => $person->slug,
+                    'name' => $person->name,
+                    'current_company' => $person->companies->first()?->name,
+                    'current_role' => $person->companies->first()?->pivot?->role,
+                    'linkedin_url' => $person->linkedin_url,
+                ]),
+            ],
+            'meta' => [
+                'source' => 'startupgraph',
+                'version' => '1.0',
+                'generated_at' => now()->toIso8601String(),
+                'query' => $query,
+                'companies_count' => $companies->count(),
+                'people_count' => $people->count(),
+            ],
+        ]);
+    }
+}

--- a/app/Http/Controllers/Api/StatsController.php
+++ b/app/Http/Controllers/Api/StatsController.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\Company;
+use App\Models\FundingRound;
+use App\Models\Person;
+use Illuminate\Http\JsonResponse;
+
+class StatsController extends Controller
+{
+    public function index(): JsonResponse
+    {
+        return response()->json([
+            'data' => [
+                'companies_count' => Company::count(),
+                'people_count' => Person::count(),
+                'funding_rounds_count' => FundingRound::count(),
+                'total_funding_tracked' => (float) FundingRound::sum('amount'),
+                'total_funding_formatted' => $this->formatAmount(FundingRound::sum('amount')),
+                'categories' => Company::CATEGORIES,
+                'countries' => Company::distinct()->pluck('country')->filter()->sort()->values(),
+            ],
+            'meta' => [
+                'source' => 'startupgraph',
+                'version' => '1.0',
+                'generated_at' => now()->toIso8601String(),
+                'description' => 'StartupGraph is an open database of startup traction data, designed to be queried by AI agents.',
+            ],
+        ]);
+    }
+
+    private function formatAmount(float $amount): string
+    {
+        if ($amount >= 1_000_000_000) {
+            return '$' . number_format($amount / 1_000_000_000, 1) . 'B';
+        }
+        if ($amount >= 1_000_000) {
+            return '$' . number_format($amount / 1_000_000, 1) . 'M';
+        }
+        if ($amount >= 1_000) {
+            return '$' . number_format($amount / 1_000, 0) . 'K';
+        }
+        return '$' . number_format($amount, 0);
+    }
+}

--- a/app/Http/Middleware/ApiCors.php
+++ b/app/Http/Middleware/ApiCors.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class ApiCors
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        // Handle preflight OPTIONS request
+        if ($request->isMethod('OPTIONS')) {
+            return response('', 200)
+                ->header('Access-Control-Allow-Origin', '*')
+                ->header('Access-Control-Allow-Methods', 'GET, OPTIONS')
+                ->header('Access-Control-Allow-Headers', 'Content-Type, Accept')
+                ->header('Access-Control-Max-Age', '86400');
+        }
+
+        $response = $next($request);
+
+        $response->headers->set('Access-Control-Allow-Origin', '*');
+        $response->headers->set('Access-Control-Allow-Methods', 'GET, OPTIONS');
+        $response->headers->set('Access-Control-Allow-Headers', 'Content-Type, Accept');
+
+        return $response;
+    }
+}

--- a/app/Http/Resources/CompanyResource.php
+++ b/app/Http/Resources/CompanyResource.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class CompanyResource extends JsonResource
+{
+    public function toArray(Request $request): array
+    {
+        return [
+            'slug' => $this->slug,
+            'name' => $this->name,
+            'website' => $this->website,
+            'description' => $this->description,
+            'category' => $this->category,
+            'category_label' => $this->category_label,
+            'founded_date' => $this->founded_date?->format('Y-m-d'),
+            'location' => [
+                'city' => $this->city,
+                'state' => $this->state,
+                'country' => $this->country,
+            ],
+            'linkedin_url' => $this->linkedin_url,
+            'current_headcount' => $this->current_headcount,
+            'product_highlights' => $this->product_highlights,
+            'total_funding' => $this->whenNotNull($this->funding_rounds_sum_amount, fn () => (float) $this->funding_rounds_sum_amount),
+            'total_funding_formatted' => $this->whenNotNull($this->funding_rounds_sum_amount, fn () => $this->formatAmount($this->funding_rounds_sum_amount)),
+            'funding_rounds_count' => $this->funding_rounds_count ?? $this->fundingRounds?->count() ?? 0,
+            'latest_funding' => $this->whenLoaded('latestFundingRound', fn () =>
+                $this->latestFundingRound ? [
+                    'round_type' => $this->latestFundingRound->round_type,
+                    'amount' => $this->latestFundingRound->amount ? (float) $this->latestFundingRound->amount : null,
+                    'amount_formatted' => $this->latestFundingRound->amount ? $this->formatAmount($this->latestFundingRound->amount) : null,
+                    'announced_date' => $this->latestFundingRound->announced_date?->format('Y-m-d'),
+                ] : null
+            ),
+            'people_count' => $this->people?->count() ?? 0,
+            'funding_rounds' => FundingRoundResource::collection($this->whenLoaded('fundingRounds')),
+            'people' => PersonSummaryResource::collection($this->whenLoaded('people')),
+            'headcount_snapshots' => HeadcountSnapshotResource::collection($this->whenLoaded('headcountSnapshots')),
+            'profile_refreshed_at' => $this->profile_refreshed_at?->toIso8601String(),
+        ];
+    }
+
+    private function formatAmount(float $amount): string
+    {
+        if ($amount >= 1_000_000_000) {
+            return '$' . number_format($amount / 1_000_000_000, 1) . 'B';
+        }
+        if ($amount >= 1_000_000) {
+            return '$' . number_format($amount / 1_000_000, 1) . 'M';
+        }
+        if ($amount >= 1_000) {
+            return '$' . number_format($amount / 1_000, 0) . 'K';
+        }
+        return '$' . number_format($amount, 0);
+    }
+}

--- a/app/Http/Resources/CompanySummaryResource.php
+++ b/app/Http/Resources/CompanySummaryResource.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class CompanySummaryResource extends JsonResource
+{
+    public function toArray(Request $request): array
+    {
+        return [
+            'slug' => $this->slug,
+            'name' => $this->name,
+            'category' => $this->category,
+            'category_label' => $this->category_label,
+            'location' => [
+                'city' => $this->city,
+                'country' => $this->country,
+            ],
+            'current_headcount' => $this->current_headcount,
+            'total_funding' => $this->funding_rounds_sum_amount ? (float) $this->funding_rounds_sum_amount : null,
+            'total_funding_formatted' => $this->funding_rounds_sum_amount ? $this->formatAmount($this->funding_rounds_sum_amount) : null,
+            'latest_funding_date' => $this->latest_funding_date,
+            'funding_rounds_count' => $this->funding_rounds_count ?? 0,
+        ];
+    }
+
+    private function formatAmount(float $amount): string
+    {
+        if ($amount >= 1_000_000_000) {
+            return '$' . number_format($amount / 1_000_000_000, 1) . 'B';
+        }
+        if ($amount >= 1_000_000) {
+            return '$' . number_format($amount / 1_000_000, 1) . 'M';
+        }
+        if ($amount >= 1_000) {
+            return '$' . number_format($amount / 1_000, 0) . 'K';
+        }
+        return '$' . number_format($amount, 0);
+    }
+}

--- a/app/Http/Resources/FundingRoundResource.php
+++ b/app/Http/Resources/FundingRoundResource.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class FundingRoundResource extends JsonResource
+{
+    public function toArray(Request $request): array
+    {
+        return [
+            'round_type' => $this->round_type,
+            'amount' => $this->amount ? (float) $this->amount : null,
+            'amount_formatted' => $this->amount ? $this->formatAmount($this->amount) : null,
+            'currency' => $this->currency,
+            'announced_date' => $this->announced_date?->format('Y-m-d'),
+            'pre_money_valuation' => $this->pre_money_valuation ? (float) $this->pre_money_valuation : null,
+            'source_url' => $this->source_url,
+            'investors' => $this->whenLoaded('investors', fn () =>
+                $this->investors->map(fn ($investor) => [
+                    'name' => $investor->name,
+                    'slug' => $investor->slug,
+                    'type' => $investor->type,
+                    'is_lead' => (bool) $investor->pivot->is_lead,
+                ])
+            ),
+        ];
+    }
+
+    private function formatAmount(float $amount): string
+    {
+        if ($amount >= 1_000_000_000) {
+            return '$' . number_format($amount / 1_000_000_000, 1) . 'B';
+        }
+        if ($amount >= 1_000_000) {
+            return '$' . number_format($amount / 1_000_000, 1) . 'M';
+        }
+        if ($amount >= 1_000) {
+            return '$' . number_format($amount / 1_000, 0) . 'K';
+        }
+        return '$' . number_format($amount, 0);
+    }
+}

--- a/app/Http/Resources/HeadcountSnapshotResource.php
+++ b/app/Http/Resources/HeadcountSnapshotResource.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class HeadcountSnapshotResource extends JsonResource
+{
+    public function toArray(Request $request): array
+    {
+        return [
+            'headcount' => $this->headcount,
+            'recorded_date' => $this->recorded_date?->format('Y-m-d'),
+            'source' => $this->source,
+        ];
+    }
+}

--- a/app/Http/Resources/PersonResource.php
+++ b/app/Http/Resources/PersonResource.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class PersonResource extends JsonResource
+{
+    public function toArray(Request $request): array
+    {
+        return [
+            'slug' => $this->slug,
+            'name' => $this->name,
+            'bio' => $this->bio,
+            'linkedin_url' => $this->linkedin_url,
+            'twitter_url' => $this->twitter_url,
+            'photo_url' => $this->photo_url,
+            'companies' => $this->whenLoaded('companies', fn () =>
+                $this->companies->map(fn ($company) => [
+                    'slug' => $company->slug,
+                    'name' => $company->name,
+                    'role' => $company->pivot->role,
+                    'is_current' => (bool) $company->pivot->is_current,
+                    'started_at' => $company->pivot->started_at,
+                    'ended_at' => $company->pivot->ended_at,
+                ])
+            ),
+        ];
+    }
+}

--- a/app/Http/Resources/PersonSummaryResource.php
+++ b/app/Http/Resources/PersonSummaryResource.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class PersonSummaryResource extends JsonResource
+{
+    public function toArray(Request $request): array
+    {
+        return [
+            'slug' => $this->slug,
+            'name' => $this->name,
+            'role' => $this->pivot?->role,
+            'is_current' => $this->pivot ? (bool) $this->pivot->is_current : null,
+            'linkedin_url' => $this->linkedin_url,
+        ];
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Middleware\AdminAuth;
+use App\Http\Middleware\ApiCors;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
@@ -8,12 +9,18 @@ use Illuminate\Foundation\Configuration\Middleware;
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
         web: __DIR__.'/../routes/web.php',
+        api: __DIR__.'/../routes/api.php',
         commands: __DIR__.'/../routes/console.php',
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware): void {
         $middleware->alias([
             'admin.auth' => AdminAuth::class,
+        ]);
+
+        // Add CORS middleware to all API routes
+        $middleware->api(prepend: [
+            ApiCors::class,
         ]);
     })
     ->withExceptions(function (Exceptions $exceptions): void {

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -1,0 +1,89 @@
+# StartupGraph MCP Server
+
+An MCP (Model Context Protocol) server that allows Claude Code and other AI agents to query startup traction data from StartupGraph.
+
+## Installation
+
+### Option 1: npx (recommended)
+
+```bash
+claude mcp add startupgraph -- npx @startupgraph/mcp
+```
+
+### Option 2: Global install
+
+```bash
+npm install -g @startupgraph/mcp
+claude mcp add startupgraph -- startupgraph-mcp
+```
+
+### Option 3: Local development
+
+```bash
+# Clone the repo
+git clone https://github.com/dmorrill/startupgraph.git
+cd startupgraph/mcp-server
+
+# Install and build
+npm install
+npm run build
+
+# Add to Claude Code
+claude mcp add startupgraph-local -- node /path/to/startupgraph/mcp-server/build/index.js
+```
+
+## Configuration
+
+### Custom API URL
+
+By default, the server connects to `http://localhost:8000/api`. To use a different URL:
+
+```bash
+# Via command line
+claude mcp add startupgraph -- npx @startupgraph/mcp --url https://startupgraph.dev/api
+
+# Via environment variable
+STARTUPGRAPH_API_URL=https://startupgraph.dev/api npx @startupgraph/mcp
+```
+
+## Available Tools
+
+| Tool | Description |
+|------|-------------|
+| `search_companies` | Search for companies by name, industry, or location |
+| `get_company` | Get detailed traction data for a specific company |
+| `get_funding_history` | Get complete funding rounds with investors |
+| `get_leadership` | Get company executives and team |
+| `get_headcount_history` | Get employee count over time |
+| `compare_companies` | Compare 2-5 companies side-by-side |
+| `list_categories` | List available category filters |
+| `get_stats` | Get database statistics |
+
+## Example Usage
+
+Once installed, you can ask Claude Code questions like:
+
+- "What's Stripe's funding history?"
+- "Compare OpenAI and Anthropic"
+- "Find AI companies in San Francisco"
+- "Who are the executives at Figma?"
+- "How has Notion's headcount grown?"
+
+## Development
+
+```bash
+cd mcp-server
+
+# Install dependencies
+npm install
+
+# Build
+npm run build
+
+# Watch mode for development
+npm run dev
+```
+
+## License
+
+MIT

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "@startupgraph/mcp",
+  "version": "1.0.0",
+  "description": "MCP server for StartupGraph - query startup traction data from Claude Code",
+  "type": "module",
+  "main": "./build/index.js",
+  "bin": {
+    "startupgraph-mcp": "./build/index.js"
+  },
+  "scripts": {
+    "build": "tsc && chmod 755 build/index.js",
+    "dev": "tsc --watch",
+    "start": "node ./build/index.js",
+    "prepublishOnly": "npm run build"
+  },
+  "files": [
+    "build"
+  ],
+  "keywords": [
+    "mcp",
+    "claude",
+    "startups",
+    "funding",
+    "crunchbase",
+    "ai",
+    "claude-code"
+  ],
+  "author": "",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dmorrill/startupgraph.git",
+    "directory": "mcp-server"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.0.0",
+    "zod": "^3.23.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.6.0"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  }
+}

--- a/mcp-server/src/client.ts
+++ b/mcp-server/src/client.ts
@@ -1,0 +1,95 @@
+import type {
+  ApiResponse,
+  Company,
+  CompanySummary,
+  FundingResponse,
+  HeadcountResponse,
+  PaginatedResponse,
+  PeopleResponse,
+  Person,
+  SearchResponse,
+  StatsResponse,
+} from "./types.js";
+
+export class StartupGraphClient {
+  private baseUrl: string;
+
+  constructor(baseUrl: string = "http://localhost:8000/api") {
+    this.baseUrl = baseUrl.replace(/\/$/, "");
+  }
+
+  private async fetch<T>(path: string): Promise<T> {
+    const url = `${this.baseUrl}${path}`;
+    const response = await fetch(url, {
+      headers: {
+        Accept: "application/json",
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(`API request failed: ${response.status} ${response.statusText}`);
+    }
+
+    return response.json() as Promise<T>;
+  }
+
+  async getStats(): Promise<ApiResponse<StatsResponse>> {
+    return this.fetch("/stats");
+  }
+
+  async searchCompanies(params: {
+    q?: string;
+    category?: string;
+    country?: string;
+    limit?: number;
+  }): Promise<ApiResponse<SearchResponse>> {
+    const searchParams = new URLSearchParams();
+    if (params.q) searchParams.set("q", params.q);
+    if (params.category) searchParams.set("category", params.category);
+    if (params.country) searchParams.set("country", params.country);
+    if (params.limit) searchParams.set("limit", params.limit.toString());
+
+    return this.fetch(`/search?${searchParams.toString()}`);
+  }
+
+  async listCompanies(params: {
+    q?: string;
+    category?: string;
+    country?: string;
+    sort?: string;
+    order?: "asc" | "desc";
+    per_page?: number;
+    page?: number;
+  } = {}): Promise<PaginatedResponse<CompanySummary>> {
+    const searchParams = new URLSearchParams();
+    if (params.q) searchParams.set("q", params.q);
+    if (params.category) searchParams.set("category", params.category);
+    if (params.country) searchParams.set("country", params.country);
+    if (params.sort) searchParams.set("sort", params.sort);
+    if (params.order) searchParams.set("order", params.order);
+    if (params.per_page) searchParams.set("per_page", params.per_page.toString());
+    if (params.page) searchParams.set("page", params.page.toString());
+
+    return this.fetch(`/companies?${searchParams.toString()}`);
+  }
+
+  async getCompany(slug: string): Promise<ApiResponse<Company>> {
+    return this.fetch(`/companies/${encodeURIComponent(slug)}`);
+  }
+
+  async getCompanyFunding(slug: string): Promise<ApiResponse<FundingResponse>> {
+    return this.fetch(`/companies/${encodeURIComponent(slug)}/funding`);
+  }
+
+  async getCompanyPeople(slug: string): Promise<ApiResponse<PeopleResponse>> {
+    return this.fetch(`/companies/${encodeURIComponent(slug)}/people`);
+  }
+
+  async getCompanyHeadcount(slug: string): Promise<ApiResponse<HeadcountResponse>> {
+    return this.fetch(`/companies/${encodeURIComponent(slug)}/headcount`);
+  }
+
+  async getPerson(slug: string): Promise<ApiResponse<Person>> {
+    return this.fetch(`/people/${encodeURIComponent(slug)}`);
+  }
+}

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -1,0 +1,492 @@
+#!/usr/bin/env node
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { z } from "zod";
+import { StartupGraphClient } from "./client.js";
+
+// Parse command line arguments
+const args = process.argv.slice(2);
+let apiUrl = process.env.STARTUPGRAPH_API_URL || "http://localhost:8000/api";
+
+for (let i = 0; i < args.length; i++) {
+  if (args[i] === "--url" && args[i + 1]) {
+    apiUrl = args[i + 1];
+    i++;
+  }
+}
+
+const client = new StartupGraphClient(apiUrl);
+
+const server = new McpServer({
+  name: "startupgraph",
+  version: "1.0.0",
+});
+
+// Tool: search_companies
+server.tool(
+  "search_companies",
+  "Search for startup companies by name, industry, or location. Returns matching companies with funding and headcount data.",
+  {
+    query: z.string().describe("Search query (company name, industry keyword, city, or country)"),
+    category: z.string().optional().describe("Filter by category: ai_ml, fintech, enterprise, healthcare, robotics, space, climate, consumer, developer_tools, defense"),
+    country: z.string().optional().describe("Filter by country name"),
+    limit: z.number().optional().default(10).describe("Maximum results to return (default: 10, max: 50)"),
+  },
+  async ({ query, category, country, limit }) => {
+    try {
+      const response = await client.searchCompanies({
+        q: query,
+        category,
+        country,
+        limit: Math.min(limit || 10, 50),
+      });
+
+      const { companies, people } = response.data;
+
+      let text = `Found ${companies.length} companies`;
+      if (people.length > 0) {
+        text += ` and ${people.length} people`;
+      }
+      text += ` matching "${query}":\n\n`;
+
+      if (companies.length > 0) {
+        text += "## Companies\n\n";
+        for (const company of companies) {
+          text += `**${company.name}** (${company.slug})\n`;
+          if (company.category_label) text += `  Category: ${company.category_label}\n`;
+          if (company.location.city || company.location.country) {
+            text += `  Location: ${[company.location.city, company.location.country].filter(Boolean).join(", ")}\n`;
+          }
+          if (company.total_funding_formatted) text += `  Total Funding: ${company.total_funding_formatted}\n`;
+          if (company.current_headcount) text += `  Employees: ${company.current_headcount}\n`;
+          text += "\n";
+        }
+      }
+
+      if (people.length > 0) {
+        text += "## People\n\n";
+        for (const person of people) {
+          text += `**${person.name}** (${person.slug})`;
+          if (person.current_role && person.current_company) {
+            text += ` - ${person.current_role} at ${person.current_company}`;
+          }
+          text += "\n";
+        }
+      }
+
+      return { content: [{ type: "text", text }] };
+    } catch (error) {
+      return {
+        content: [{
+          type: "text",
+          text: `Error searching companies: ${error instanceof Error ? error.message : String(error)}`,
+        }],
+      };
+    }
+  }
+);
+
+// Tool: get_company
+server.tool(
+  "get_company",
+  "Get detailed traction data for a specific company including funding history, employee count, leadership, and product highlights.",
+  {
+    slug: z.string().describe("Company slug (URL-friendly identifier, e.g., 'stripe' or 'openai')"),
+  },
+  async ({ slug }) => {
+    try {
+      const response = await client.getCompany(slug);
+      const company = response.data;
+
+      let text = `# ${company.name}\n\n`;
+
+      if (company.website) text += `Website: ${company.website}\n`;
+      if (company.description) text += `\n${company.description}\n`;
+
+      text += "\n## Overview\n\n";
+      if (company.category_label) text += `- **Category:** ${company.category_label}\n`;
+      if (company.founded_date) text += `- **Founded:** ${company.founded_date}\n`;
+      if (company.location.city || company.location.country) {
+        text += `- **Location:** ${[company.location.city, company.location.state, company.location.country].filter(Boolean).join(", ")}\n`;
+      }
+      if (company.current_headcount) text += `- **Employees:** ${company.current_headcount}\n`;
+      if (company.linkedin_url) text += `- **LinkedIn:** ${company.linkedin_url}\n`;
+
+      text += "\n## Funding\n\n";
+      if (company.total_funding_formatted) {
+        text += `- **Total Raised:** ${company.total_funding_formatted}\n`;
+      }
+      text += `- **Funding Rounds:** ${company.funding_rounds_count}\n`;
+      if (company.latest_funding) {
+        const lf = company.latest_funding;
+        text += `- **Latest Round:** ${lf.round_type || "Unknown"}`;
+        if (lf.amount_formatted) text += ` (${lf.amount_formatted})`;
+        if (lf.announced_date) text += ` on ${lf.announced_date}`;
+        text += "\n";
+      }
+
+      if (company.product_highlights && company.product_highlights.length > 0) {
+        text += "\n## Product Highlights\n\n";
+        for (const highlight of company.product_highlights) {
+          text += `- ${highlight}\n`;
+        }
+      }
+
+      if (company.people && company.people.length > 0) {
+        text += "\n## Leadership\n\n";
+        const current = company.people.filter(p => p.is_current !== false);
+        for (const person of current.slice(0, 5)) {
+          text += `- **${person.name}**`;
+          if (person.role) text += ` - ${person.role}`;
+          text += "\n";
+        }
+        if (current.length > 5) {
+          text += `- ... and ${current.length - 5} more\n`;
+        }
+      }
+
+      return { content: [{ type: "text", text }] };
+    } catch (error) {
+      return {
+        content: [{
+          type: "text",
+          text: `Error fetching company: ${error instanceof Error ? error.message : String(error)}`,
+        }],
+      };
+    }
+  }
+);
+
+// Tool: get_funding_history
+server.tool(
+  "get_funding_history",
+  "Get complete funding history for a company including all rounds, amounts, dates, and investors.",
+  {
+    slug: z.string().describe("Company slug (e.g., 'stripe')"),
+  },
+  async ({ slug }) => {
+    try {
+      const response = await client.getCompanyFunding(slug);
+      const data = response.data;
+
+      let text = `# Funding History: ${data.company_name}\n\n`;
+      text += `**Total Raised:** ${data.total_funding_formatted}\n`;
+      text += `**Rounds:** ${data.rounds_count}\n\n`;
+
+      if (data.funding_rounds.length > 0) {
+        text += "## Rounds\n\n";
+        for (const round of data.funding_rounds) {
+          text += `### ${round.round_type || "Unknown Round"}`;
+          if (round.announced_date) text += ` (${round.announced_date})`;
+          text += "\n";
+
+          if (round.amount_formatted) text += `- **Amount:** ${round.amount_formatted}\n`;
+          if (round.pre_money_valuation) text += `- **Pre-money Valuation:** $${(round.pre_money_valuation / 1_000_000).toFixed(0)}M\n`;
+
+          if (round.investors && round.investors.length > 0) {
+            const leads = round.investors.filter(i => i.is_lead);
+            const others = round.investors.filter(i => !i.is_lead);
+
+            if (leads.length > 0) {
+              text += `- **Lead Investors:** ${leads.map(i => i.name).join(", ")}\n`;
+            }
+            if (others.length > 0) {
+              text += `- **Investors:** ${others.map(i => i.name).join(", ")}\n`;
+            }
+          }
+
+          if (round.source_url) text += `- **Source:** ${round.source_url}\n`;
+          text += "\n";
+        }
+      }
+
+      return { content: [{ type: "text", text }] };
+    } catch (error) {
+      return {
+        content: [{
+          type: "text",
+          text: `Error fetching funding history: ${error instanceof Error ? error.message : String(error)}`,
+        }],
+      };
+    }
+  }
+);
+
+// Tool: get_leadership
+server.tool(
+  "get_leadership",
+  "Get the leadership team and executives of a company.",
+  {
+    slug: z.string().describe("Company slug (e.g., 'stripe')"),
+  },
+  async ({ slug }) => {
+    try {
+      const response = await client.getCompanyPeople(slug);
+      const data = response.data;
+
+      let text = `# Leadership: ${data.company_name}\n\n`;
+      text += `**Total:** ${data.total_count} people (${data.current_count} current)\n\n`;
+
+      if (data.current.length > 0) {
+        text += "## Current Team\n\n";
+        for (const person of data.current) {
+          text += `- **${person.name}**`;
+          if (person.role) text += ` - ${person.role}`;
+          if (person.linkedin_url) text += ` ([LinkedIn](${person.linkedin_url}))`;
+          text += "\n";
+        }
+      }
+
+      if (data.former.length > 0) {
+        text += "\n## Former\n\n";
+        for (const person of data.former) {
+          text += `- **${person.name}**`;
+          if (person.role) text += ` - ${person.role}`;
+          text += "\n";
+        }
+      }
+
+      return { content: [{ type: "text", text }] };
+    } catch (error) {
+      return {
+        content: [{
+          type: "text",
+          text: `Error fetching leadership: ${error instanceof Error ? error.message : String(error)}`,
+        }],
+      };
+    }
+  }
+);
+
+// Tool: get_headcount_history
+server.tool(
+  "get_headcount_history",
+  "Get employee headcount history and growth metrics for a company.",
+  {
+    slug: z.string().describe("Company slug (e.g., 'stripe')"),
+  },
+  async ({ slug }) => {
+    try {
+      const response = await client.getCompanyHeadcount(slug);
+      const data = response.data;
+
+      let text = `# Employee Growth: ${data.company_name}\n\n`;
+
+      if (data.current_headcount) {
+        text += `**Current Employees:** ${data.current_headcount}\n`;
+      }
+      if (data.growth_percent !== null && data.growth_percent !== undefined) {
+        text += `**Growth:** ${data.growth_percent > 0 ? "+" : ""}${data.growth_percent}%\n`;
+      }
+      text += `**Data Points:** ${data.snapshots_count}\n\n`;
+
+      if (data.snapshots.length > 0) {
+        text += "## History\n\n";
+        text += "| Date | Headcount | Source |\n";
+        text += "|------|-----------|--------|\n";
+        for (const snapshot of data.snapshots) {
+          text += `| ${snapshot.recorded_date || "N/A"} | ${snapshot.headcount} | ${snapshot.source || "N/A"} |\n`;
+        }
+      }
+
+      return { content: [{ type: "text", text }] };
+    } catch (error) {
+      return {
+        content: [{
+          type: "text",
+          text: `Error fetching headcount history: ${error instanceof Error ? error.message : String(error)}`,
+        }],
+      };
+    }
+  }
+);
+
+// Tool: compare_companies
+server.tool(
+  "compare_companies",
+  "Compare multiple companies side-by-side on funding, headcount, and other metrics.",
+  {
+    slugs: z.array(z.string()).min(2).max(5).describe("Array of company slugs to compare (2-5 companies)"),
+  },
+  async ({ slugs }) => {
+    try {
+      const companies = await Promise.all(
+        slugs.map(async (slug) => {
+          try {
+            const response = await client.getCompany(slug);
+            return response.data;
+          } catch {
+            return null;
+          }
+        })
+      );
+
+      const validCompanies = companies.filter((c): c is NonNullable<typeof c> => c !== null);
+
+      if (validCompanies.length === 0) {
+        return {
+          content: [{
+            type: "text",
+            text: "No valid companies found for the provided slugs.",
+          }],
+        };
+      }
+
+      let text = `# Company Comparison\n\n`;
+      text += `Comparing ${validCompanies.length} companies:\n\n`;
+
+      // Header row
+      text += "| Metric |";
+      for (const c of validCompanies) {
+        text += ` ${c.name} |`;
+      }
+      text += "\n|--------|";
+      for (const _ of validCompanies) {
+        text += "---------|";
+      }
+      text += "\n";
+
+      // Category
+      text += "| Category |";
+      for (const c of validCompanies) {
+        text += ` ${c.category_label || "N/A"} |`;
+      }
+      text += "\n";
+
+      // Founded
+      text += "| Founded |";
+      for (const c of validCompanies) {
+        text += ` ${c.founded_date || "N/A"} |`;
+      }
+      text += "\n";
+
+      // Location
+      text += "| Location |";
+      for (const c of validCompanies) {
+        const loc = [c.location.city, c.location.country].filter(Boolean).join(", ");
+        text += ` ${loc || "N/A"} |`;
+      }
+      text += "\n";
+
+      // Employees
+      text += "| Employees |";
+      for (const c of validCompanies) {
+        text += ` ${c.current_headcount?.toLocaleString() || "N/A"} |`;
+      }
+      text += "\n";
+
+      // Total Funding
+      text += "| Total Funding |";
+      for (const c of validCompanies) {
+        text += ` ${c.total_funding_formatted || "N/A"} |`;
+      }
+      text += "\n";
+
+      // Rounds
+      text += "| Funding Rounds |";
+      for (const c of validCompanies) {
+        text += ` ${c.funding_rounds_count} |`;
+      }
+      text += "\n";
+
+      // Latest Round
+      text += "| Latest Round |";
+      for (const c of validCompanies) {
+        if (c.latest_funding) {
+          text += ` ${c.latest_funding.round_type || "?"} (${c.latest_funding.amount_formatted || "?"}) |`;
+        } else {
+          text += " N/A |";
+        }
+      }
+      text += "\n";
+
+      return { content: [{ type: "text", text }] };
+    } catch (error) {
+      return {
+        content: [{
+          type: "text",
+          text: `Error comparing companies: ${error instanceof Error ? error.message : String(error)}`,
+        }],
+      };
+    }
+  }
+);
+
+// Tool: list_categories
+server.tool(
+  "list_categories",
+  "List all available company categories for filtering searches.",
+  {},
+  async () => {
+    try {
+      const response = await client.getStats();
+      const categories = response.data.categories;
+
+      let text = "# Available Categories\n\n";
+      text += "Use these category keys when filtering company searches:\n\n";
+
+      for (const [key, label] of Object.entries(categories)) {
+        text += `- **${key}** - ${label}\n`;
+      }
+
+      return { content: [{ type: "text", text }] };
+    } catch (error) {
+      return {
+        content: [{
+          type: "text",
+          text: `Error fetching categories: ${error instanceof Error ? error.message : String(error)}`,
+        }],
+      };
+    }
+  }
+);
+
+// Tool: get_stats
+server.tool(
+  "get_stats",
+  "Get overall database statistics - total companies, people, funding tracked, etc.",
+  {},
+  async () => {
+    try {
+      const response = await client.getStats();
+      const stats = response.data;
+
+      let text = "# StartupGraph Statistics\n\n";
+      text += `- **Companies:** ${stats.companies_count}\n`;
+      text += `- **People:** ${stats.people_count}\n`;
+      text += `- **Funding Rounds:** ${stats.funding_rounds_count}\n`;
+      text += `- **Total Funding Tracked:** ${stats.total_funding_formatted}\n\n`;
+
+      text += "## Categories\n\n";
+      for (const [key, label] of Object.entries(stats.categories)) {
+        text += `- ${label} (\`${key}\`)\n`;
+      }
+
+      text += "\n## Countries\n\n";
+      text += stats.countries.join(", ");
+
+      return { content: [{ type: "text", text }] };
+    } catch (error) {
+      return {
+        content: [{
+          type: "text",
+          text: `Error fetching stats: ${error instanceof Error ? error.message : String(error)}`,
+        }],
+      };
+    }
+  }
+);
+
+// Run the server
+async function main() {
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+  console.error(`StartupGraph MCP Server v1.0.0`);
+  console.error(`API URL: ${apiUrl}`);
+}
+
+main().catch((error) => {
+  console.error("Fatal error:", error);
+  process.exit(1);
+});

--- a/mcp-server/src/types.ts
+++ b/mcp-server/src/types.ts
@@ -1,0 +1,164 @@
+export interface Company {
+  slug: string;
+  name: string;
+  website?: string;
+  description?: string;
+  category?: string;
+  category_label?: string;
+  founded_date?: string;
+  location: {
+    city?: string;
+    state?: string;
+    country?: string;
+  };
+  linkedin_url?: string;
+  current_headcount?: number;
+  product_highlights?: string[];
+  total_funding?: number;
+  total_funding_formatted?: string;
+  funding_rounds_count: number;
+  latest_funding?: {
+    round_type: string;
+    amount?: number;
+    amount_formatted?: string;
+    announced_date?: string;
+  };
+  people_count: number;
+  funding_rounds?: FundingRound[];
+  people?: PersonSummary[];
+  headcount_snapshots?: HeadcountSnapshot[];
+  profile_refreshed_at?: string;
+}
+
+export interface CompanySummary {
+  slug: string;
+  name: string;
+  category?: string;
+  category_label?: string;
+  location: {
+    city?: string;
+    country?: string;
+  };
+  current_headcount?: number;
+  total_funding?: number;
+  total_funding_formatted?: string;
+  latest_funding_date?: string;
+  funding_rounds_count: number;
+}
+
+export interface FundingRound {
+  round_type?: string;
+  amount?: number;
+  amount_formatted?: string;
+  currency: string;
+  announced_date?: string;
+  pre_money_valuation?: number;
+  source_url?: string;
+  investors?: Investor[];
+}
+
+export interface Investor {
+  name: string;
+  slug: string;
+  type?: string;
+  is_lead: boolean;
+}
+
+export interface Person {
+  slug: string;
+  name: string;
+  bio?: string;
+  linkedin_url?: string;
+  twitter_url?: string;
+  photo_url?: string;
+  companies?: CompanyRole[];
+}
+
+export interface PersonSummary {
+  slug: string;
+  name: string;
+  role?: string;
+  is_current?: boolean;
+  linkedin_url?: string;
+}
+
+export interface CompanyRole {
+  slug: string;
+  name: string;
+  role?: string;
+  is_current: boolean;
+  started_at?: string;
+  ended_at?: string;
+}
+
+export interface HeadcountSnapshot {
+  headcount: number;
+  recorded_date?: string;
+  source?: string;
+}
+
+export interface ApiResponse<T> {
+  data: T;
+  meta: {
+    source: string;
+    version: string;
+    generated_at: string;
+  };
+}
+
+export interface PaginatedResponse<T> extends ApiResponse<T[]> {
+  pagination: {
+    total: number;
+    per_page: number;
+    current_page: number;
+    last_page: number;
+  };
+}
+
+export interface SearchResponse {
+  companies: CompanySummary[];
+  people: {
+    slug: string;
+    name: string;
+    current_company?: string;
+    current_role?: string;
+    linkedin_url?: string;
+  }[];
+}
+
+export interface StatsResponse {
+  companies_count: number;
+  people_count: number;
+  funding_rounds_count: number;
+  total_funding_tracked: number;
+  total_funding_formatted: string;
+  categories: Record<string, string>;
+  countries: string[];
+}
+
+export interface FundingResponse {
+  company_slug: string;
+  company_name: string;
+  total_funding: number;
+  total_funding_formatted: string;
+  rounds_count: number;
+  funding_rounds: FundingRound[];
+}
+
+export interface PeopleResponse {
+  company_slug: string;
+  company_name: string;
+  total_count: number;
+  current_count: number;
+  current: PersonSummary[];
+  former: PersonSummary[];
+}
+
+export interface HeadcountResponse {
+  company_slug: string;
+  company_name: string;
+  current_headcount?: number;
+  snapshots_count: number;
+  growth_percent?: number;
+  snapshots: HeadcountSnapshot[];
+}

--- a/mcp-server/tsconfig.json
+++ b/mcp-server/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "outDir": "./build",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "build"]
+}

--- a/resources/views/companies/show.blade.php
+++ b/resources/views/companies/show.blade.php
@@ -2,6 +2,68 @@
 
 @section('title', $company->name . ' - StartupGraph')
 
+@push('head')
+<script type="application/ld+json">
+{
+    "@context": "https://schema.org",
+    "@type": "Organization",
+    "name": @json($company->name),
+    "url": @json($company->website),
+    @if($company->description)
+    "description": @json($company->description),
+    @endif
+    @if($company->founded_date)
+    "foundingDate": "{{ $company->founded_date->format('Y-m-d') }}",
+    @endif
+    @if($company->city || $company->country)
+    "address": {
+        "@type": "PostalAddress"
+        @if($company->city)
+        ,"addressLocality": @json($company->city)
+        @endif
+        @if($company->state)
+        ,"addressRegion": @json($company->state)
+        @endif
+        @if($company->country)
+        ,"addressCountry": @json($company->country)
+        @endif
+    },
+    @endif
+    @if($company->current_headcount)
+    "numberOfEmployees": {
+        "@type": "QuantitativeValue",
+        "value": {{ $company->current_headcount }}
+    },
+    @endif
+    @if($company->linkedin_url)
+    "sameAs": [@json($company->linkedin_url)],
+    @endif
+    "additionalProperty": [
+        @if($company->category)
+        {
+            "@type": "PropertyValue",
+            "name": "category",
+            "value": @json($company->category)
+        },
+        @endif
+        @if($company->fundingRounds->sum('amount'))
+        {
+            "@type": "PropertyValue",
+            "name": "totalFunding",
+            "value": {{ $company->fundingRounds->sum('amount') }},
+            "unitCode": "USD"
+        },
+        @endif
+        {
+            "@type": "PropertyValue",
+            "name": "fundingRoundsCount",
+            "value": {{ $company->fundingRounds->count() }}
+        }
+    ]
+}
+</script>
+@endpush
+
 @section('content')
 <div class="space-y-6">
     <div class="flex items-center gap-2 text-sm">

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,0 +1,45 @@
+<?php
+
+use App\Http\Controllers\Api\CompanyController;
+use App\Http\Controllers\Api\PersonController;
+use App\Http\Controllers\Api\SearchController;
+use App\Http\Controllers\Api\StatsController;
+use Illuminate\Support\Facades\Route;
+
+/*
+|--------------------------------------------------------------------------
+| API Routes
+|--------------------------------------------------------------------------
+|
+| StartupGraph Public API - No authentication required.
+| Designed to be queried by AI agents like Claude Code.
+|
+*/
+
+// Database stats
+Route::get('/stats', [StatsController::class, 'index']);
+
+// Search across companies and people
+Route::get('/search', [SearchController::class, 'index']);
+
+// Companies
+Route::get('/companies', [CompanyController::class, 'index']);
+Route::get('/companies/{company}', [CompanyController::class, 'show']);
+Route::get('/companies/{company}/funding', [CompanyController::class, 'funding']);
+Route::get('/companies/{company}/people', [CompanyController::class, 'people']);
+Route::get('/companies/{company}/headcount', [CompanyController::class, 'headcount']);
+
+// People
+Route::get('/people/{person}', [PersonController::class, 'show']);
+
+// Categories list (for filtering)
+Route::get('/categories', fn () => response()->json([
+    'data' => collect(\App\Models\Company::CATEGORIES)->map(fn ($label, $key) => [
+        'key' => $key,
+        'label' => $label,
+    ])->values(),
+    'meta' => [
+        'source' => 'startupgraph',
+        'version' => '1.0',
+    ],
+]));


### PR DESCRIPTION
## Summary

Makes StartupGraph queryable by Claude Code and other AI agents, positioning it as an open alternative to Crunchbase/PitchBook which block automated access with 403 errors.

- **Public JSON API** - No auth, no rate limits, CORS open to all
- **MCP Server** - TypeScript package for direct Claude Code integration
- **JSON-LD** - Structured data in HTML for WebFetch fallback

## API Endpoints

| Endpoint | Description |
|----------|-------------|
| `GET /api/stats` | Database statistics |
| `GET /api/search?q=` | Search companies and people |
| `GET /api/companies` | List companies with filters |
| `GET /api/companies/{slug}` | Full company profile |
| `GET /api/companies/{slug}/funding` | Funding history |
| `GET /api/companies/{slug}/people` | Leadership team |
| `GET /api/companies/{slug}/headcount` | Employee growth |
| `GET /api/people/{slug}` | Person profile |

## MCP Tools

| Tool | Description |
|------|-------------|
| `search_companies` | Find companies by name, industry, location |
| `get_company` | Full traction profile |
| `get_funding_history` | Funding rounds with investors |
| `get_leadership` | Company executives |
| `get_headcount_history` | Employee growth over time |
| `compare_companies` | Side-by-side comparison |

## Usage

```bash
# Add MCP server to Claude Code
claude mcp add startupgraph -- npx @startupgraph/mcp --url http://localhost:8000/api

# Then ask questions like:
# "What's Stripe's funding history?"
# "Compare OpenAI and Anthropic"
```

## Test plan

- [ ] Run `composer install` and `php artisan serve`
- [ ] Test API endpoints: `curl http://localhost:8000/api/stats`
- [ ] Build MCP server: `cd mcp-server && npm install && npm run build`
- [ ] Add to Claude Code and test tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)