### PR TITLE
Add rate limiting to admin authentication

### DIFF
--- a/app/Http/Middleware/AdminAuth.php
+++ b/app/Http/Middleware/AdminAuth.php
@@ -4,6 +4,7 @@ namespace App\Http\Middleware;
 
 use Closure;
 use Illuminate\Http\Request;
+use Illuminate\Cache\RateLimiter;
 use Symfony\Component\HttpFoundation\Response;
 
 class AdminAuth
@@ -13,6 +14,8 @@ class AdminAuth
      *
      * Uses HTTP Basic Auth with credentials from environment variables.
      * Set ADMIN_USERNAME and ADMIN_PASSWORD in your .env file.
+     *
+     * Rate-limited to 5 failed attempts per minute per IP to prevent brute-force attacks.
      */
     public function handle(Request $request, Closure $next): Response
     {
@@ -24,13 +27,30 @@ class AdminAuth
             return response('Admin credentials not configured.', 503);
         }
 
+        // Rate limit by IP address
+        $rateLimiter = app(RateLimiter::class);
+        $key = 'admin-auth:' . $request->ip();
+
+        if ($rateLimiter->tooManyAttempts($key, 5)) {
+            $retryAfter = $rateLimiter->availableIn($key);
+
+            return response('Too many authentication attempts. Please try again later.', 429, [
+                'Retry-After' => $retryAfter,
+            ]);
+        }
+
         // Check for HTTP Basic Auth credentials using timing-safe comparison
         $providedUser = $request->getUser() ?? '';
         $providedPass = $request->getPassword() ?? '';
 
         if (!hash_equals($username, $providedUser) || !hash_equals($password, $providedPass)) {
+            $rateLimiter->hit($key, 60);
+
             return response('Unauthorized.', 401, ['WWW-Authenticate' => 'Basic realm="Admin Area"']);
         }
+
+        // Clear rate limit on successful auth
+        $rateLimiter->clear($key);
 
         return $next($request);
     }


### PR DESCRIPTION
## Changes

### Rate limiting on admin auth (security hardening)
- Added rate limiting to the `AdminAuth` middleware: 5 failed attempts per minute per IP
- Returns 429 with `Retry-After` header when limit exceeded
- Clears rate limit counter on successful authentication
- Prevents brute-force attacks against HTTP Basic Auth admin area

### Note on DB transaction for company deletion
The `Admin\CompanyController::destroy()` method already wraps all related deletions in `DB::transaction()`, so no changes needed there.