### PR TITLE
Lazy-load Chart.js only on pages that need it

### DIFF
--- a/resources/views/companies/show.blade.php
+++ b/resources/views/companies/show.blade.php
@@ -288,7 +288,7 @@
 </div>
 
 @if($company->headcountSnapshots->count() >= 2 || $company->fundingRounds->where('amount', '>', 0)->count() >= 2)
-@push('head')
+@push('scripts')
 <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 <script>
 (function() {

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -36,5 +36,7 @@
             </p>
         </div>
     </footer>
+
+    @stack('scripts')
 </body>
 </html>


### PR DESCRIPTION
Move Chart.js from `@push('head')` to `@push('scripts')` so it only loads on pages that need it (currently the company show page). Added `@stack('scripts')` to the layout before `</body>` for better page load performance.

Closes #8