### PR TITLE
Add indie project tracking, Product Hunt discovery & public submission form

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -71,3 +71,4 @@ ADMIN_PASSWORD=change-me-in-production
 # Crunchbase API (optional - discovery source for recently funded startups)
 # Get a key at https://data.crunchbase.com/docs/using-the-api
 CRUNCHBASE_API_KEY=
+PRODUCT_HUNT_TOKEN=

--- a/app/Http/Controllers/Admin/SubmissionController.php
+++ b/app/Http/Controllers/Admin/SubmissionController.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\Company;
+use App\Models\CompanySubmission;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Str;
+use Illuminate\View\View;
+
+class SubmissionController extends Controller
+{
+    public function index(Request $request): View
+    {
+        $query = CompanySubmission::query()->orderByDesc('created_at');
+
+        if ($status = $request->get('status')) {
+            $query->where('status', $status);
+        } else {
+            $query->where('status', 'pending');
+        }
+
+        $submissions = $query->paginate(50)->withQueryString();
+
+        return view('admin.submissions.index', compact('submissions'));
+    }
+
+    public function approve(CompanySubmission $submission): RedirectResponse
+    {
+        $slug = Str::slug($submission->name);
+        $original = $slug;
+        $counter = 1;
+        while (Company::where('slug', $slug)->exists()) {
+            $slug = "{$original}-{$counter}";
+            $counter++;
+        }
+
+        Company::create([
+            'name' => $submission->name,
+            'slug' => $slug,
+            'website' => $submission->url,
+            'description' => $submission->description,
+            'is_indie' => true,
+            'tech_stack' => $submission->tech_stack,
+            'submitted_by' => $submission->builder_name,
+            'submission_url' => $submission->source_url,
+        ]);
+
+        $submission->update(['status' => 'approved']);
+
+        return redirect()->route('admin.submissions.index')
+            ->with('success', "'{$submission->name}' approved and added to companies.");
+    }
+
+    public function reject(CompanySubmission $submission): RedirectResponse
+    {
+        $submission->update(['status' => 'rejected']);
+
+        return redirect()->route('admin.submissions.index')
+            ->with('success', "'{$submission->name}' rejected.");
+    }
+}

--- a/app/Http/Controllers/SubmissionController.php
+++ b/app/Http/Controllers/SubmissionController.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\CompanySubmission;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\View\View;
+
+class SubmissionController extends Controller
+{
+    public function create(): View
+    {
+        return view('submissions.create');
+    }
+
+    public function store(Request $request): RedirectResponse
+    {
+        $validated = $request->validate([
+            'name' => ['required', 'string', 'max:255'],
+            'url' => ['nullable', 'url', 'max:255'],
+            'description' => ['nullable', 'string', 'max:5000'],
+            'builder_name' => ['nullable', 'string', 'max:255'],
+            'tech_stack' => ['nullable', 'string', 'max:1000'],
+            'submitter_email' => ['nullable', 'email', 'max:255'],
+            'source_url' => ['nullable', 'url', 'max:255'],
+        ]);
+
+        CompanySubmission::create($validated);
+
+        return redirect()->route('submissions.create')
+            ->with('success', 'Thanks! Your project has been submitted for review.');
+    }
+}

--- a/app/Models/Company.php
+++ b/app/Models/Company.php
@@ -40,6 +40,13 @@ class Company extends Model
         'profile_refreshed_at',
         'headcount_fetched_at',
         'headcount_fetch_day',
+        'is_indie',
+        'is_open_source',
+        'github_stars',
+        'solo_builder',
+        'tech_stack',
+        'submitted_by',
+        'submission_url',
     ];
 
     protected $casts = [
@@ -47,6 +54,10 @@ class Company extends Model
         'product_highlights' => 'array',
         'profile_refreshed_at' => 'datetime',
         'headcount_fetched_at' => 'datetime',
+        'is_indie' => 'boolean',
+        'is_open_source' => 'boolean',
+        'solo_builder' => 'boolean',
+        'github_stars' => 'integer',
     ];
 
     public function headcountSnapshots(): HasMany

--- a/app/Models/CompanySubmission.php
+++ b/app/Models/CompanySubmission.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class CompanySubmission extends Model
+{
+    protected $fillable = [
+        'name',
+        'url',
+        'description',
+        'builder_name',
+        'tech_stack',
+        'submitter_email',
+        'source_url',
+        'status',
+    ];
+}

--- a/app/Services/DiscoverCompaniesService.php
+++ b/app/Services/DiscoverCompaniesService.php
@@ -8,6 +8,7 @@ use App\Services\Discovery\CrunchbaseDiscoverySource;
 use App\Services\Discovery\HackerNewsDiscoverySource;
 use App\Services\Discovery\TechCrunchDiscoverySource;
 use App\Services\Discovery\WellfoundDiscoverySource;
+use App\Services\Discovery\ProductHuntDiscoverySource;
 use App\Services\Discovery\YCombinatorDiscoverySource;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
@@ -23,12 +24,14 @@ class DiscoverCompaniesService
         CrunchbaseDiscoverySource $crunchbase,
         WellfoundDiscoverySource $wellfound,
         HackerNewsDiscoverySource $hackerNews,
+        ProductHuntDiscoverySource $productHunt,
     ) {
         $this->registerSource($techCrunch);
         $this->registerSource($yCombinator);
         $this->registerSource($crunchbase);
         $this->registerSource($wellfound);
         $this->registerSource($hackerNews);
+        $this->registerSource($productHunt);
     }
 
     public function registerSource(CompanyDiscoverySource $source): void
@@ -110,6 +113,9 @@ class DiscoverCompaniesService
                         'slug' => $this->generateUniqueSlug($companyName),
                         'description' => $candidate['description'] ?? null,
                         'website' => $candidate['website'] ?? null,
+                        'is_indie' => $candidate['is_indie'] ?? false,
+                        'solo_builder' => $candidate['solo_builder'] ?? false,
+                        'submission_url' => $candidate['source_url'] ?? null,
                     ]);
 
                     // If we have funding info, create a funding round

--- a/app/Services/Discovery/ProductHuntDiscoverySource.php
+++ b/app/Services/Discovery/ProductHuntDiscoverySource.php
@@ -1,0 +1,222 @@
+<?php
+
+namespace App\Services\Discovery;
+
+use App\Contracts\CompanyDiscoverySource;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+
+class ProductHuntDiscoverySource implements CompanyDiscoverySource
+{
+    private const API_URL = 'https://api.producthunt.com/v2/api/graphql';
+
+    /**
+     * Keywords that signal indie/AI-built projects.
+     */
+    private const INDIE_KEYWORDS = [
+        'vibe coded',
+        'vibe-coded',
+        'built with cursor',
+        'built with ai',
+        'built with claude',
+        'built with chatgpt',
+        'built with copilot',
+        'weekend project',
+        'solo maker',
+        'solo founder',
+        'indie hacker',
+        'side project',
+        'one person',
+        'built in a weekend',
+        'bootstrapped',
+        'no-code',
+        'open source',
+    ];
+
+    public function name(): string
+    {
+        return 'producthunt';
+    }
+
+    public function discover(int $days = 7): array
+    {
+        $token = config('services.producthunt.token');
+
+        if ($token) {
+            return $this->discoverViaApi($token, $days);
+        }
+
+        Log::info('ProductHunt: No API token configured, falling back to web scraping');
+        return $this->discoverViaScraping();
+    }
+
+    private function discoverViaApi(string $token, int $days): array
+    {
+        $companies = [];
+        $postedAfter = now()->subDays($days)->toIso8601String();
+
+        $query = <<<'GRAPHQL'
+        query($postedAfter: DateTime, $cursor: String) {
+            posts(first: 50, postedAfter: $postedAfter, after: $cursor) {
+                edges {
+                    node {
+                        id
+                        name
+                        tagline
+                        description
+                        url
+                        website
+                        votesCount
+                        makers {
+                            id
+                            name
+                        }
+                    }
+                }
+                pageInfo {
+                    endCursor
+                    hasNextPage
+                }
+            }
+        }
+        GRAPHQL;
+
+        $cursor = null;
+        $pages = 0;
+        $maxPages = 5;
+
+        while ($pages < $maxPages) {
+            try {
+                $response = Http::timeout(15)
+                    ->withHeaders([
+                        'Authorization' => "Bearer {$token}",
+                        'Content-Type' => 'application/json',
+                    ])
+                    ->post(self::API_URL, [
+                        'query' => $query,
+                        'variables' => [
+                            'postedAfter' => $postedAfter,
+                            'cursor' => $cursor,
+                        ],
+                    ]);
+
+                if (!$response->successful()) {
+                    Log::warning("ProductHunt API error: HTTP {$response->status()}");
+                    break;
+                }
+
+                $data = $response->json('data.posts');
+                if (!$data) {
+                    break;
+                }
+
+                foreach ($data['edges'] as $edge) {
+                    $post = $edge['node'];
+                    $combined = strtolower(($post['tagline'] ?? '') . ' ' . ($post['description'] ?? ''));
+
+                    if (!$this->hasIndieSignals($combined, $post)) {
+                        continue;
+                    }
+
+                    $companies[] = [
+                        'name' => $post['name'],
+                        'description' => $post['tagline'] ?? $post['description'] ?? null,
+                        'website' => $post['website'] ?? null,
+                        'source_url' => $post['url'] ?? null,
+                        'is_indie' => true,
+                        'solo_builder' => count($post['makers'] ?? []) <= 1,
+                    ];
+                }
+
+                if (!($data['pageInfo']['hasNextPage'] ?? false)) {
+                    break;
+                }
+
+                $cursor = $data['pageInfo']['endCursor'];
+                $pages++;
+            } catch (\Exception $e) {
+                Log::warning("ProductHunt API error: {$e->getMessage()}");
+                break;
+            }
+        }
+
+        return $companies;
+    }
+
+    private function discoverViaScraping(): array
+    {
+        $companies = [];
+
+        try {
+            $response = Http::timeout(15)
+                ->withHeaders([
+                    'User-Agent' => 'Mozilla/5.0 (compatible; StartupGraph/1.0)',
+                ])
+                ->get('https://www.producthunt.com/leaderboard/daily');
+
+            if (!$response->successful()) {
+                Log::warning("ProductHunt scrape error: HTTP {$response->status()}");
+                return [];
+            }
+
+            $html = $response->body();
+
+            // Extract product names and links from the leaderboard page
+            // PH uses data attributes and structured markup
+            preg_match_all(
+                '/<a[^>]*href="\/posts\/([^"]+)"[^>]*>.*?<h3[^>]*>([^<]+)<\/h3>/s',
+                $html,
+                $matches,
+                PREG_SET_ORDER
+            );
+
+            if (empty($matches)) {
+                // Try alternate pattern - PH changes markup frequently
+                preg_match_all(
+                    '/data-test="post-name"[^>]*>([^<]+)</s',
+                    $html,
+                    $nameMatches
+                );
+
+                foreach ($nameMatches[1] ?? [] as $name) {
+                    $companies[] = [
+                        'name' => trim($name),
+                        'description' => 'Discovered via Product Hunt daily leaderboard',
+                        'source_url' => 'https://www.producthunt.com/leaderboard/daily',
+                        'is_indie' => true,
+                    ];
+                }
+            } else {
+                foreach ($matches as $match) {
+                    $companies[] = [
+                        'name' => trim($match[2]),
+                        'website' => null,
+                        'description' => 'Discovered via Product Hunt daily leaderboard',
+                        'source_url' => "https://www.producthunt.com/posts/{$match[1]}",
+                        'is_indie' => true,
+                    ];
+                }
+            }
+        } catch (\Exception $e) {
+            Log::warning("ProductHunt scrape error: {$e->getMessage()}");
+        }
+
+        return $companies;
+    }
+
+    private function hasIndieSignals(string $text, array $post): bool
+    {
+        foreach (self::INDIE_KEYWORDS as $keyword) {
+            if (str_contains($text, $keyword)) {
+                return true;
+            }
+        }
+
+        // Solo maker signal
+        if (count($post['makers'] ?? []) === 1) {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/config/services.php
+++ b/config/services.php
@@ -43,4 +43,8 @@ return [
         'token' => env('GITHUB_TOKEN'),
     ],
 
+    'producthunt' => [
+        'token' => env('PRODUCT_HUNT_TOKEN'),
+    ],
+
 ];

--- a/database/migrations/2026_02_15_160000_add_indie_fields_to_companies_table.php
+++ b/database/migrations/2026_02_15_160000_add_indie_fields_to_companies_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('companies', function (Blueprint $table) {
+            $table->boolean('is_indie')->default(false)->after('category');
+            $table->boolean('is_open_source')->default(false)->after('is_indie');
+            $table->integer('github_stars')->nullable()->after('is_open_source');
+            $table->boolean('solo_builder')->default(false)->after('github_stars');
+            $table->text('tech_stack')->nullable()->after('solo_builder');
+            $table->string('submitted_by')->nullable()->after('tech_stack');
+            $table->string('submission_url')->nullable()->after('submitted_by');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('companies', function (Blueprint $table) {
+            $table->dropColumn([
+                'is_indie',
+                'is_open_source',
+                'github_stars',
+                'solo_builder',
+                'tech_stack',
+                'submitted_by',
+                'submission_url',
+            ]);
+        });
+    }
+};

--- a/database/migrations/2026_02_15_160100_create_company_submissions_table.php
+++ b/database/migrations/2026_02_15_160100_create_company_submissions_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('company_submissions', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('url')->nullable();
+            $table->text('description')->nullable();
+            $table->string('builder_name')->nullable();
+            $table->text('tech_stack')->nullable();
+            $table->string('submitter_email')->nullable();
+            $table->string('source_url')->nullable();
+            $table->enum('status', ['pending', 'approved', 'rejected'])->default('pending');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('company_submissions');
+    }
+};

--- a/resources/views/admin/submissions/index.blade.php
+++ b/resources/views/admin/submissions/index.blade.php
@@ -1,0 +1,86 @@
+@extends('layouts.app')
+
+@section('title', 'Review Submissions - Admin - StartupGraph')
+
+@section('content')
+<div class="flex justify-between items-center mb-6">
+    <h1 class="text-2xl font-bold text-gray-900">Submissions</h1>
+    <div class="flex space-x-2">
+        <a href="{{ route('admin.submissions.index', ['status' => 'pending']) }}"
+           class="px-3 py-1 text-sm rounded-md {{ request('status', 'pending') === 'pending' ? 'bg-gray-800 text-white' : 'bg-gray-200 text-gray-700' }}">
+            Pending
+        </a>
+        <a href="{{ route('admin.submissions.index', ['status' => 'approved']) }}"
+           class="px-3 py-1 text-sm rounded-md {{ request('status') === 'approved' ? 'bg-gray-800 text-white' : 'bg-gray-200 text-gray-700' }}">
+            Approved
+        </a>
+        <a href="{{ route('admin.submissions.index', ['status' => 'rejected']) }}"
+           class="px-3 py-1 text-sm rounded-md {{ request('status') === 'rejected' ? 'bg-gray-800 text-white' : 'bg-gray-200 text-gray-700' }}">
+            Rejected
+        </a>
+    </div>
+</div>
+
+@if (session('success'))
+    <div class="bg-green-50 border border-green-200 text-green-800 px-4 py-3 rounded-md mb-6">
+        {{ session('success') }}
+    </div>
+@endif
+
+@if ($submissions->isEmpty())
+    <p class="text-gray-500">No {{ request('status', 'pending') }} submissions.</p>
+@else
+    <div class="bg-white shadow overflow-hidden rounded-lg">
+        <table class="min-w-full divide-y divide-gray-200">
+            <thead class="bg-gray-50">
+                <tr>
+                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Name</th>
+                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Builder</th>
+                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">URL</th>
+                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Submitted</th>
+                    <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase">Actions</th>
+                </tr>
+            </thead>
+            <tbody class="bg-white divide-y divide-gray-200">
+                @foreach ($submissions as $submission)
+                    <tr>
+                        <td class="px-6 py-4 whitespace-nowrap">
+                            <div class="text-sm font-medium text-gray-900">{{ $submission->name }}</div>
+                            @if ($submission->description)
+                                <div class="text-sm text-gray-500 truncate max-w-xs">{{ $submission->description }}</div>
+                            @endif
+                        </td>
+                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{{ $submission->builder_name ?? '-' }}</td>
+                        <td class="px-6 py-4 whitespace-nowrap text-sm">
+                            @if ($submission->url)
+                                <a href="{{ $submission->url }}" target="_blank" class="text-blue-600 hover:underline">{{ parse_url($submission->url, PHP_URL_HOST) }}</a>
+                            @else
+                                -
+                            @endif
+                        </td>
+                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{{ $submission->created_at->diffForHumans() }}</td>
+                        <td class="px-6 py-4 whitespace-nowrap text-right text-sm space-x-2">
+                            @if ($submission->status === 'pending')
+                                <form method="POST" action="{{ route('admin.submissions.approve', $submission) }}" class="inline">
+                                    @csrf
+                                    <button type="submit" class="text-green-600 hover:text-green-800 font-medium">Approve</button>
+                                </form>
+                                <form method="POST" action="{{ route('admin.submissions.reject', $submission) }}" class="inline">
+                                    @csrf
+                                    <button type="submit" class="text-red-600 hover:text-red-800 font-medium">Reject</button>
+                                </form>
+                            @else
+                                <span class="text-gray-400">{{ ucfirst($submission->status) }}</span>
+                            @endif
+                        </td>
+                    </tr>
+                @endforeach
+            </tbody>
+        </table>
+    </div>
+
+    <div class="mt-4">
+        {{ $submissions->links() }}
+    </div>
+@endif
+@endsection

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -28,6 +28,9 @@
                     <a href="{{ route('open-source.index') }}" class="text-gray-600 hover:text-gray-900">
                         Open Source
                     </a>
+                    <a href="{{ route('submissions.create') }}" class="text-gray-600 hover:text-gray-900">
+                        Submit a Project
+                    </a>
 
                     @auth
                         <div x-data="{ open: false }" class="relative">

--- a/resources/views/submissions/create.blade.php
+++ b/resources/views/submissions/create.blade.php
@@ -1,0 +1,80 @@
+@extends('layouts.app')
+
+@section('title', 'Submit a Project - StartupGraph')
+
+@section('content')
+<div class="max-w-2xl mx-auto">
+    <h1 class="text-3xl font-bold text-gray-900 mb-2">Submit a Project</h1>
+    <p class="text-gray-600 mb-8">Know an interesting indie startup or AI-built project? Submit it for inclusion in StartupGraph.</p>
+
+    @if (session('success'))
+        <div class="bg-green-50 border border-green-200 text-green-800 px-4 py-3 rounded-md mb-6">
+            {{ session('success') }}
+        </div>
+    @endif
+
+    @if ($errors->any())
+        <div class="bg-red-50 border border-red-200 text-red-800 px-4 py-3 rounded-md mb-6">
+            <ul class="list-disc list-inside">
+                @foreach ($errors->all() as $error)
+                    <li>{{ $error }}</li>
+                @endforeach
+            </ul>
+        </div>
+    @endif
+
+    <form method="POST" action="{{ route('submissions.store') }}" class="space-y-6">
+        @csrf
+
+        <div>
+            <label for="name" class="block text-sm font-medium text-gray-700">Company / Project Name *</label>
+            <input type="text" name="name" id="name" value="{{ old('name') }}" required
+                   class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-gray-500 focus:ring-gray-500 sm:text-sm px-3 py-2 border">
+        </div>
+
+        <div>
+            <label for="url" class="block text-sm font-medium text-gray-700">Website URL</label>
+            <input type="url" name="url" id="url" value="{{ old('url') }}" placeholder="https://"
+                   class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-gray-500 focus:ring-gray-500 sm:text-sm px-3 py-2 border">
+        </div>
+
+        <div>
+            <label for="description" class="block text-sm font-medium text-gray-700">Description</label>
+            <textarea name="description" id="description" rows="3"
+                      class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-gray-500 focus:ring-gray-500 sm:text-sm px-3 py-2 border">{{ old('description') }}</textarea>
+        </div>
+
+        <div>
+            <label for="builder_name" class="block text-sm font-medium text-gray-700">Builder Name</label>
+            <input type="text" name="builder_name" id="builder_name" value="{{ old('builder_name') }}"
+                   class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-gray-500 focus:ring-gray-500 sm:text-sm px-3 py-2 border">
+        </div>
+
+        <div>
+            <label for="tech_stack" class="block text-sm font-medium text-gray-700">Tech Stack</label>
+            <input type="text" name="tech_stack" id="tech_stack" value="{{ old('tech_stack') }}" placeholder="Laravel, React, Cursor, etc."
+                   class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-gray-500 focus:ring-gray-500 sm:text-sm px-3 py-2 border">
+        </div>
+
+        <div>
+            <label for="submitter_email" class="block text-sm font-medium text-gray-700">Your Email (optional)</label>
+            <input type="email" name="submitter_email" id="submitter_email" value="{{ old('submitter_email') }}"
+                   class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-gray-500 focus:ring-gray-500 sm:text-sm px-3 py-2 border">
+        </div>
+
+        <div>
+            <label for="source_url" class="block text-sm font-medium text-gray-700">Launch Post Link</label>
+            <p class="text-xs text-gray-500 mt-0.5">Link to X/Twitter, LinkedIn, Product Hunt, or other launch post</p>
+            <input type="url" name="source_url" id="source_url" value="{{ old('source_url') }}" placeholder="https://"
+                   class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-gray-500 focus:ring-gray-500 sm:text-sm px-3 py-2 border">
+        </div>
+
+        <div>
+            <button type="submit"
+                    class="inline-flex items-center px-4 py-2 bg-gray-800 text-white text-sm font-medium rounded-md hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500">
+                Submit Project
+            </button>
+        </div>
+    </form>
+</div>
+@endsection

--- a/routes/console.php
+++ b/routes/console.php
@@ -77,6 +77,12 @@ Schedule::command('app:refresh-oss-stars')
     ->onOneServer()
     ->appendOutputTo(storage_path('logs/oss-refresh-stars.log'));
 
+Schedule::command('companies:discover --source=producthunt')
+    ->dailyAt('05:15')
+    ->withoutOverlapping()
+    ->onOneServer()
+    ->appendOutputTo(storage_path('logs/companies-discover.log'));
+
 // Daily news fetch - runs at 3am
 Schedule::command('news:fetch')
     ->dailyAt('03:00')

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,7 +2,9 @@
 
 use App\Http\Controllers\CompanyController;
 use App\Http\Controllers\CompareController;
+use App\Http\Controllers\SubmissionController;
 use App\Http\Controllers\Admin\CompanyController as AdminCompanyController;
+use App\Http\Controllers\Admin\SubmissionController as AdminSubmissionController;
 use App\Http\Controllers\PersonController;
 use App\Http\Controllers\OpenSourceController;
 use App\Http\Controllers\ProfileController;
@@ -18,6 +20,9 @@ Route::get('/companies/{company}', [CompanyController::class, 'show'])->name('co
 Route::get('/people/{person}', [PersonController::class, 'show'])->name('people.show');
 Route::get('/open-source', [OpenSourceController::class, 'index'])->name('open-source.index');
 
+Route::get('/submit', [SubmissionController::class, 'create'])->name('submissions.create');
+Route::post('/submit', [SubmissionController::class, 'store'])->name('submissions.store');
+
 // Admin routes
 Route::prefix('admin')->middleware(['throttle:10,1', 'admin.auth'])->name('admin.')->group(function () {
     Route::get('/companies', [AdminCompanyController::class, 'index'])->name('companies.index');
@@ -31,6 +36,10 @@ Route::prefix('admin')->middleware(['throttle:10,1', 'admin.auth'])->name('admin
     Route::get('/oss-projects/{ossProject}', [AdminOssProjectController::class, 'show'])->name('oss-projects.show');
     Route::post('/oss-projects/{ossProject}/link-company', [AdminOssProjectController::class, 'linkCompany'])->name('oss-projects.link-company');
     Route::delete('/oss-projects/{ossProject}/unlink-company/{company}', [AdminOssProjectController::class, 'unlinkCompany'])->name('oss-projects.unlink-company');
+
+    Route::get('/submissions', [AdminSubmissionController::class, 'index'])->name('submissions.index');
+    Route::post('/submissions/{submission}/approve', [AdminSubmissionController::class, 'approve'])->name('submissions.approve');
+    Route::post('/submissions/{submission}/reject', [AdminSubmissionController::class, 'reject'])->name('submissions.reject');
 });
 
 // Authenticated user routes


### PR DESCRIPTION
## What

Adds indie/solo-builder project tracking to StartupGraph with three components:

### 1. Data Model Updates
- New fields on `companies`: `is_indie`, `is_open_source`, `github_stars`, `solo_builder`, `tech_stack`, `submitted_by`, `submission_url`

### 2. Product Hunt Discovery
- New `ProductHuntDiscoverySource` integrated into existing discovery system
- Uses PH GraphQL API (with `PRODUCT_HUNT_TOKEN` env var), falls back to web scraping
- Filters for indie signals: solo makers, AI-built keywords, side projects
- Scheduled daily at 5:15 AM alongside other sources

### 3. Public Submission Form
- `/submit` — no auth required, anyone can submit a project
- New `company_submissions` table with pending/approved/rejected workflow
- Admin review at `/admin/submissions` with approve/reject actions
- "Submit a Project" added to main nav

### Setup
```bash
php artisan migrate
# Optional: add PRODUCT_HUNT_TOKEN to .env for API access
```

Closes #50