### PR TITLE
feat: GitHub open-source project tracking (Phase 1)

### DIFF
--- a/app/Console/Commands/DiscoverOssProjects.php
+++ b/app/Console/Commands/DiscoverOssProjects.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Services\GitHubDiscoveryService;
+use Illuminate\Console\Command;
+
+class DiscoverOssProjects extends Command
+{
+    protected $signature = 'app:discover-oss-projects';
+    protected $description = 'Discover open-source projects from GitHub topics and awesome-selfhosted';
+
+    public function handle(GitHubDiscoveryService $service): int
+    {
+        $this->info('Starting GitHub OSS discovery...');
+
+        $stats = $service->discover();
+
+        $this->info("Discovery complete: {$stats['created']} created, {$stats['updated']} updated, {$stats['errors']} errors");
+
+        return $stats['errors'] > 0 ? self::FAILURE : self::SUCCESS;
+    }
+}

--- a/app/Console/Commands/RefreshOssStars.php
+++ b/app/Console/Commands/RefreshOssStars.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\OpenSourceProject;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+
+class RefreshOssStars extends Command
+{
+    protected $signature = 'app:refresh-oss-stars {--limit=0 : Max projects to refresh (0 = all)}';
+    protected $description = 'Refresh star counts, forks, and last commit dates for all OSS projects';
+
+    public function handle(): int
+    {
+        $token = config('services.github.token') ?: env('GITHUB_TOKEN');
+        $limit = (int) $this->option('limit');
+
+        $query = OpenSourceProject::query()->orderBy('updated_at', 'asc');
+        if ($limit > 0) {
+            $query->limit($limit);
+        }
+
+        $projects = $query->get();
+        $this->info("Refreshing {$projects->count()} OSS projects...");
+
+        $bar = $this->output->createProgressBar($projects->count());
+        $updated = 0;
+        $errors = 0;
+
+        foreach ($projects as $project) {
+            try {
+                $request = Http::timeout(15)
+                    ->withHeaders([
+                        'Accept' => 'application/vnd.github+json',
+                        'X-GitHub-Api-Version' => '2022-11-28',
+                    ]);
+
+                if ($token) {
+                    $request = $request->withToken($token);
+                }
+
+                $response = $request->get("https://api.github.com/repos/{$project->github_owner}/{$project->github_repo}");
+
+                if ($response->successful()) {
+                    $repo = $response->json();
+                    $project->update([
+                        'stars' => $repo['stargazers_count'] ?? $project->stars,
+                        'forks' => $repo['forks_count'] ?? $project->forks,
+                        'watchers' => $repo['watchers_count'] ?? $project->watchers,
+                        'last_commit_at' => $repo['pushed_at'] ?? $project->last_commit_at,
+                        'primary_language' => $repo['language'] ?? $project->primary_language,
+                        'license' => $repo['license']['spdx_id'] ?? $project->license,
+                        'topics' => $repo['topics'] ?? $project->topics,
+                    ]);
+                    $updated++;
+                } elseif ($response->status() === 403) {
+                    // Rate limited
+                    $resetAt = $response->header('X-RateLimit-Reset');
+                    $waitSeconds = $resetAt ? max(1, (int) $resetAt - time()) : 60;
+                    $this->warn("\nRate limited. Waiting {$waitSeconds}s...");
+                    sleep(min($waitSeconds, 300));
+                    continue;
+                } else {
+                    Log::debug("Failed to refresh {$project->github_owner}/{$project->github_repo}: {$response->status()}");
+                    $errors++;
+                }
+            } catch (\Throwable $e) {
+                Log::debug("Error refreshing {$project->github_owner}/{$project->github_repo}: {$e->getMessage()}");
+                $errors++;
+            }
+
+            $bar->advance();
+            sleep(1); // Rate limit: ~1 request per second
+        }
+
+        $bar->finish();
+        $this->newLine();
+        $this->info("Done: {$updated} updated, {$errors} errors");
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Http/Controllers/Admin/OssProjectController.php
+++ b/app/Http/Controllers/Admin/OssProjectController.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\OpenSourceProject;
+use App\Models\Company;
+use Illuminate\Http\Request;
+use Illuminate\View\View;
+use Illuminate\Http\RedirectResponse;
+
+class OssProjectController extends Controller
+{
+    public function index(Request $request): View
+    {
+        $query = OpenSourceProject::query()->orderByDesc('stars');
+
+        if ($search = $request->get('search')) {
+            $escaped = str_replace(['%', '_'], ['\%', '\_'], $search);
+            $query->where(function ($q) use ($escaped) {
+                $q->where('name', 'like', "%{$escaped}%")
+                  ->orWhere('github_owner', 'like', "%{$escaped}%")
+                  ->orWhere('description', 'like', "%{$escaped}%");
+            });
+        }
+
+        if ($category = $request->get('category')) {
+            $query->where('category', $category);
+        }
+
+        $projects = $query->paginate(50)->withQueryString();
+        $categories = OpenSourceProject::whereNotNull('category')
+            ->distinct()
+            ->pluck('category')
+            ->sort();
+
+        return view('admin.oss-projects.index', compact('projects', 'categories'));
+    }
+
+    public function show(OpenSourceProject $ossProject): View
+    {
+        $ossProject->load('companies');
+        $companies = Company::orderBy('name')->get(['id', 'name']);
+
+        return view('admin.oss-projects.show', compact('ossProject', 'companies'));
+    }
+
+    public function linkCompany(Request $request, OpenSourceProject $ossProject): RedirectResponse
+    {
+        $validated = $request->validate([
+            'company_id' => 'required|exists:companies,id',
+            'relationship_type' => 'required|in:alternative_to,fork_of,built_on,commercial_version_of',
+            'notes' => 'nullable|string|max:500',
+        ]);
+
+        $ossProject->companies()->syncWithoutDetaching([
+            $validated['company_id'] => [
+                'relationship_type' => $validated['relationship_type'],
+                'notes' => $validated['notes'] ?? null,
+            ],
+        ]);
+
+        return back()->with('success', 'Company linked successfully.');
+    }
+
+    public function unlinkCompany(OpenSourceProject $ossProject, Company $company): RedirectResponse
+    {
+        $ossProject->companies()->detach($company->id);
+
+        return back()->with('success', 'Company unlinked.');
+    }
+}

--- a/app/Http/Controllers/OpenSourceController.php
+++ b/app/Http/Controllers/OpenSourceController.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\OpenSourceProject;
+use Illuminate\Http\Request;
+use Illuminate\View\View;
+
+class OpenSourceController extends Controller
+{
+    public function index(Request $request): View
+    {
+        $query = OpenSourceProject::query()->orderByDesc('stars');
+
+        if ($search = $request->get('search')) {
+            $escaped = str_replace(['%', '_'], ['\%', '\_'], $search);
+            $query->where(function ($q) use ($escaped) {
+                $q->where('name', 'like', "%{$escaped}%")
+                  ->orWhere('description', 'like', "%{$escaped}%")
+                  ->orWhere('primary_language', 'like', "%{$escaped}%");
+            });
+        }
+
+        if ($language = $request->get('language')) {
+            $query->where('primary_language', $language);
+        }
+
+        if ($request->boolean('self_hostable')) {
+            $query->where('self_hostable', true);
+        }
+
+        $projects = $query->paginate(50)->withQueryString();
+        $languages = OpenSourceProject::whereNotNull('primary_language')
+            ->distinct()
+            ->pluck('primary_language')
+            ->sort();
+
+        return view('open-source.index', compact('projects', 'languages'));
+    }
+}

--- a/app/Models/Company.php
+++ b/app/Models/Company.php
@@ -76,6 +76,13 @@ class Company extends Model
             ->withTimestamps();
     }
 
+    public function ossAlternatives(): BelongsToMany
+    {
+        return $this->belongsToMany(OpenSourceProject::class, 'company_oss_alternatives', 'company_id', 'oss_project_id')
+            ->withPivot('relationship_type', 'notes')
+            ->withTimestamps();
+    }
+
     public function scheduledTaskExecutions(): HasMany
     {
         return $this->hasMany(ScheduledTaskExecution::class);

--- a/app/Models/OpenSourceProject.php
+++ b/app/Models/OpenSourceProject.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+
+class OpenSourceProject extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'name',
+        'github_url',
+        'github_owner',
+        'github_repo',
+        'description',
+        'stars',
+        'forks',
+        'watchers',
+        'contributors_count',
+        'primary_language',
+        'topics',
+        'license',
+        'last_commit_at',
+        'github_created_at',
+        'category',
+        'self_hostable',
+        'has_commercial_version',
+        'commercial_url',
+    ];
+
+    protected $casts = [
+        'topics' => 'array',
+        'stars' => 'integer',
+        'forks' => 'integer',
+        'watchers' => 'integer',
+        'contributors_count' => 'integer',
+        'last_commit_at' => 'datetime',
+        'github_created_at' => 'datetime',
+        'self_hostable' => 'boolean',
+        'has_commercial_version' => 'boolean',
+    ];
+
+    public function companies(): BelongsToMany
+    {
+        return $this->belongsToMany(Company::class, 'company_oss_alternatives', 'oss_project_id', 'company_id')
+            ->withPivot('relationship_type', 'notes')
+            ->withTimestamps();
+    }
+}

--- a/app/Services/GitHubDiscoveryService.php
+++ b/app/Services/GitHubDiscoveryService.php
@@ -1,0 +1,221 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\OpenSourceProject;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+
+class GitHubDiscoveryService
+{
+    private const SEARCH_TOPICS = [
+        'self-hosted',
+        'open-source-alternative',
+        'selfhosted',
+        'ai',
+        'llm',
+        'machine-learning',
+    ];
+
+    private const MIN_STARS = 500;
+    private const AWESOME_SELFHOSTED_REPO = 'awesome-selfhosted/awesome-selfhosted';
+
+    private ?string $token;
+
+    public function __construct()
+    {
+        $this->token = config('services.github.token') ?: env('GITHUB_TOKEN');
+    }
+
+    /**
+     * Run full discovery: topic search + awesome-selfhosted parsing.
+     */
+    public function discover(): array
+    {
+        $stats = ['created' => 0, 'updated' => 0, 'errors' => 0];
+
+        foreach (self::SEARCH_TOPICS as $topic) {
+            try {
+                $topicStats = $this->discoverByTopic($topic);
+                $stats['created'] += $topicStats['created'];
+                $stats['updated'] += $topicStats['updated'];
+            } catch (\Throwable $e) {
+                Log::error("GitHub discovery error for topic '{$topic}': {$e->getMessage()}");
+                $stats['errors']++;
+            }
+            sleep(2); // Rate limit between topic searches
+        }
+
+        try {
+            $awesomeStats = $this->discoverFromAwesomeSelfhosted();
+            $stats['created'] += $awesomeStats['created'];
+            $stats['updated'] += $awesomeStats['updated'];
+        } catch (\Throwable $e) {
+            Log::error("Awesome-selfhosted discovery error: {$e->getMessage()}");
+            $stats['errors']++;
+        }
+
+        Log::info('GitHub OSS discovery complete', $stats);
+
+        return $stats;
+    }
+
+    /**
+     * Search GitHub repos by topic, filtered by stars and activity.
+     */
+    public function discoverByTopic(string $topic): array
+    {
+        $stats = ['created' => 0, 'updated' => 0];
+        $pushedAfter = now()->subYear()->format('Y-m-d');
+
+        $page = 1;
+        do {
+            $response = $this->githubRequest('https://api.github.com/search/repositories', [
+                'q' => "topic:{$topic} stars:>" . self::MIN_STARS . " pushed:>{$pushedAfter}",
+                'sort' => 'stars',
+                'order' => 'desc',
+                'per_page' => 100,
+                'page' => $page,
+            ]);
+
+            if (!$response->successful()) {
+                Log::warning("GitHub search failed for topic '{$topic}': {$response->status()}");
+                break;
+            }
+
+            $data = $response->json();
+            $items = $data['items'] ?? [];
+
+            foreach ($items as $repo) {
+                $result = $this->upsertProject($repo);
+                $stats[$result]++;
+            }
+
+            $page++;
+            $totalPages = ceil(($data['total_count'] ?? 0) / 100);
+            sleep(2); // Rate limit between pages
+
+        } while ($page <= $totalPages && $page <= 10); // Max 10 pages (1000 results)
+
+        return $stats;
+    }
+
+    /**
+     * Parse awesome-selfhosted README for GitHub project URLs.
+     */
+    public function discoverFromAwesomeSelfhosted(): array
+    {
+        $stats = ['created' => 0, 'updated' => 0];
+
+        $response = $this->githubRequest(
+            'https://api.github.com/repos/' . self::AWESOME_SELFHOSTED_REPO . '/readme',
+            [],
+            ['Accept' => 'application/vnd.github.raw']
+        );
+
+        if (!$response->successful()) {
+            Log::warning('Failed to fetch awesome-selfhosted README: ' . $response->status());
+            return $stats;
+        }
+
+        $readme = $response->body();
+
+        // Extract GitHub URLs from markdown links: [Name](https://github.com/owner/repo)
+        preg_match_all(
+            '/\[([^\]]+)\]\((https:\/\/github\.com\/([a-zA-Z0-9._-]+)\/([a-zA-Z0-9._-]+))\)/',
+            $readme,
+            $matches,
+            PREG_SET_ORDER
+        );
+
+        $seen = [];
+        foreach ($matches as $match) {
+            $githubUrl = rtrim($match[2], '/');
+            if (isset($seen[$githubUrl])) {
+                continue;
+            }
+            $seen[$githubUrl] = true;
+
+            // Fetch repo details from API to get stars etc.
+            try {
+                $repoResponse = $this->githubRequest(
+                    "https://api.github.com/repos/{$match[3]}/{$match[4]}"
+                );
+
+                if (!$repoResponse->successful()) {
+                    continue;
+                }
+
+                $repo = $repoResponse->json();
+                if (($repo['stargazers_count'] ?? 0) < self::MIN_STARS) {
+                    continue;
+                }
+
+                $result = $this->upsertProject($repo, true);
+                $stats[$result]++;
+
+                sleep(1); // Rate limit
+            } catch (\Throwable $e) {
+                Log::debug("Failed to fetch repo {$match[3]}/{$match[4]}: {$e->getMessage()}");
+            }
+        }
+
+        return $stats;
+    }
+
+    /**
+     * Upsert a project from GitHub API repo data.
+     */
+    private function upsertProject(array $repo, bool $selfHostable = false): string
+    {
+        $githubUrl = $repo['html_url'];
+
+        $data = [
+            'name' => $repo['name'],
+            'github_url' => $githubUrl,
+            'github_owner' => $repo['owner']['login'] ?? '',
+            'github_repo' => $repo['name'],
+            'description' => $repo['description'] ?? null,
+            'stars' => $repo['stargazers_count'] ?? 0,
+            'forks' => $repo['forks_count'] ?? 0,
+            'watchers' => $repo['watchers_count'] ?? 0,
+            'primary_language' => $repo['language'] ?? null,
+            'topics' => $repo['topics'] ?? null,
+            'license' => $repo['license']['spdx_id'] ?? null,
+            'last_commit_at' => isset($repo['pushed_at']) ? $repo['pushed_at'] : null,
+            'github_created_at' => isset($repo['created_at']) ? $repo['created_at'] : null,
+        ];
+
+        if ($selfHostable) {
+            $data['self_hostable'] = true;
+        }
+
+        $existing = OpenSourceProject::where('github_url', $githubUrl)->first();
+
+        if ($existing) {
+            $existing->update($data);
+            return 'updated';
+        }
+
+        OpenSourceProject::create($data);
+        return 'created';
+    }
+
+    /**
+     * Make a GitHub API request with optional token auth.
+     */
+    private function githubRequest(string $url, array $query = [], array $headers = []): \Illuminate\Http\Client\Response
+    {
+        $request = Http::timeout(30)
+            ->withHeaders(array_merge([
+                'Accept' => 'application/vnd.github+json',
+                'X-GitHub-Api-Version' => '2022-11-28',
+            ], $headers));
+
+        if ($this->token) {
+            $request = $request->withToken($this->token);
+        }
+
+        return $request->get($url, $query);
+    }
+}

--- a/config/services.php
+++ b/config/services.php
@@ -39,4 +39,8 @@ return [
         'api_key' => env('CRUNCHBASE_API_KEY'),
     ],
 
+    'github' => [
+        'token' => env('GITHUB_TOKEN'),
+    ],
+
 ];

--- a/database/migrations/2026_02_15_170000_create_open_source_projects_table.php
+++ b/database/migrations/2026_02_15_170000_create_open_source_projects_table.php
@@ -1,0 +1,43 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('open_source_projects', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('github_url')->unique();
+            $table->string('github_owner');
+            $table->string('github_repo');
+            $table->text('description')->nullable();
+            $table->integer('stars')->default(0);
+            $table->integer('forks')->default(0);
+            $table->integer('watchers')->default(0);
+            $table->integer('contributors_count')->nullable();
+            $table->string('primary_language')->nullable();
+            $table->json('topics')->nullable();
+            $table->string('license')->nullable();
+            $table->timestamp('last_commit_at')->nullable();
+            $table->timestamp('github_created_at')->nullable();
+            $table->string('category')->nullable();
+            $table->boolean('self_hostable')->default(false);
+            $table->boolean('has_commercial_version')->default(false);
+            $table->string('commercial_url')->nullable();
+            $table->timestamps();
+
+            $table->index('stars');
+            $table->index('category');
+            $table->index(['github_owner', 'github_repo']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('open_source_projects');
+    }
+};

--- a/database/migrations/2026_02_15_170100_create_company_oss_alternatives_table.php
+++ b/database/migrations/2026_02_15_170100_create_company_oss_alternatives_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('company_oss_alternatives', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('company_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('oss_project_id')->constrained('open_source_projects')->cascadeOnDelete();
+            $table->enum('relationship_type', [
+                'alternative_to',
+                'fork_of',
+                'built_on',
+                'commercial_version_of',
+            ]);
+            $table->text('notes')->nullable();
+            $table->timestamps();
+
+            $table->unique(['company_id', 'oss_project_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('company_oss_alternatives');
+    }
+};

--- a/resources/views/admin/layouts/app.blade.php
+++ b/resources/views/admin/layouts/app.blade.php
@@ -20,6 +20,9 @@
                     <a href="{{ route('admin.companies.index') }}" class="text-gray-300 hover:text-white">
                         Companies
                     </a>
+                    <a href="{{ route('admin.oss-projects.index') }}" class="text-gray-300 hover:text-white">
+                        OSS Projects
+                    </a>
                     <span class="text-gray-600">|</span>
                     <a href="{{ route('home') }}" class="text-gray-300 hover:text-white">
                         View Site

--- a/resources/views/admin/oss-projects/index.blade.php
+++ b/resources/views/admin/oss-projects/index.blade.php
@@ -1,0 +1,74 @@
+@extends('admin.layouts.app')
+
+@section('title', 'OSS Projects - Admin')
+
+@section('content')
+<div class="space-y-6">
+    <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+        <div>
+            <h1 class="text-2xl font-bold text-gray-900">Open Source Projects</h1>
+            <p class="text-gray-600">{{ $projects->total() }} projects tracked</p>
+        </div>
+    </div>
+
+    <form method="GET" action="{{ route('admin.oss-projects.index') }}" class="bg-white p-4 rounded-lg shadow-sm border">
+        <div class="flex flex-col sm:flex-row gap-4">
+            <div class="flex-1">
+                <input type="text" name="search" value="{{ request('search') }}" placeholder="Search projects..." class="w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500">
+            </div>
+            <div>
+                <select name="category" class="rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500">
+                    <option value="">All Categories</option>
+                    @foreach($categories as $cat)
+                        <option value="{{ $cat }}" {{ request('category') === $cat ? 'selected' : '' }}>{{ $cat }}</option>
+                    @endforeach
+                </select>
+            </div>
+            <button type="submit" class="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700">Search</button>
+        </div>
+    </form>
+
+    <div class="bg-white rounded-lg shadow-sm border overflow-hidden">
+        <table class="min-w-full divide-y divide-gray-200">
+            <thead class="bg-gray-50">
+                <tr>
+                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Project</th>
+                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Language</th>
+                    <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase">⭐ Stars</th>
+                    <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase">Forks</th>
+                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">License</th>
+                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Last Commit</th>
+                    <th class="px-6 py-3"></th>
+                </tr>
+            </thead>
+            <tbody class="divide-y divide-gray-200">
+                @forelse($projects as $project)
+                <tr class="hover:bg-gray-50">
+                    <td class="px-6 py-4">
+                        <div>
+                            <a href="{{ route('admin.oss-projects.show', $project) }}" class="font-medium text-blue-600 hover:text-blue-800">{{ $project->name }}</a>
+                            <p class="text-sm text-gray-500 truncate max-w-md">{{ $project->description }}</p>
+                            <p class="text-xs text-gray-400">{{ $project->github_owner }}/{{ $project->github_repo }}</p>
+                        </div>
+                    </td>
+                    <td class="px-6 py-4 text-sm text-gray-600">{{ $project->primary_language ?? '—' }}</td>
+                    <td class="px-6 py-4 text-sm text-right font-mono">{{ number_format($project->stars) }}</td>
+                    <td class="px-6 py-4 text-sm text-right font-mono">{{ number_format($project->forks) }}</td>
+                    <td class="px-6 py-4 text-sm text-gray-600">{{ $project->license ?? '—' }}</td>
+                    <td class="px-6 py-4 text-sm text-gray-600">{{ $project->last_commit_at?->diffForHumans() ?? '—' }}</td>
+                    <td class="px-6 py-4 text-right">
+                        <a href="{{ $project->github_url }}" target="_blank" class="text-gray-400 hover:text-gray-600">GitHub ↗</a>
+                    </td>
+                </tr>
+                @empty
+                <tr>
+                    <td colspan="7" class="px-6 py-12 text-center text-gray-500">No projects found. Run <code>php artisan app:discover-oss-projects</code> to import.</td>
+                </tr>
+                @endforelse
+            </tbody>
+        </table>
+    </div>
+
+    <div>{{ $projects->links() }}</div>
+</div>
+@endsection

--- a/resources/views/admin/oss-projects/show.blade.php
+++ b/resources/views/admin/oss-projects/show.blade.php
@@ -1,0 +1,92 @@
+@extends('admin.layouts.app')
+
+@section('title', $ossProject->name . ' - Admin')
+
+@section('content')
+<div class="space-y-6">
+    <div class="flex items-center justify-between">
+        <div>
+            <h1 class="text-2xl font-bold text-gray-900">{{ $ossProject->name }}</h1>
+            <p class="text-gray-500">{{ $ossProject->github_owner }}/{{ $ossProject->github_repo }}</p>
+        </div>
+        <a href="{{ $ossProject->github_url }}" target="_blank" class="px-4 py-2 bg-gray-800 text-white rounded-lg hover:bg-gray-700">View on GitHub ↗</a>
+    </div>
+
+    <div class="bg-white rounded-lg shadow-sm border p-6">
+        <div class="grid grid-cols-2 md:grid-cols-4 gap-6">
+            <div>
+                <p class="text-sm text-gray-500">Stars</p>
+                <p class="text-2xl font-bold">{{ number_format($ossProject->stars) }}</p>
+            </div>
+            <div>
+                <p class="text-sm text-gray-500">Forks</p>
+                <p class="text-2xl font-bold">{{ number_format($ossProject->forks) }}</p>
+            </div>
+            <div>
+                <p class="text-sm text-gray-500">Language</p>
+                <p class="text-2xl font-bold">{{ $ossProject->primary_language ?? '—' }}</p>
+            </div>
+            <div>
+                <p class="text-sm text-gray-500">License</p>
+                <p class="text-2xl font-bold">{{ $ossProject->license ?? '—' }}</p>
+            </div>
+        </div>
+        @if($ossProject->description)
+            <p class="mt-4 text-gray-700">{{ $ossProject->description }}</p>
+        @endif
+        @if($ossProject->topics)
+            <div class="mt-4 flex flex-wrap gap-2">
+                @foreach($ossProject->topics as $topic)
+                    <span class="px-2 py-1 bg-blue-100 text-blue-800 text-xs rounded-full">{{ $topic }}</span>
+                @endforeach
+            </div>
+        @endif
+    </div>
+
+    {{-- Linked Companies --}}
+    <div class="bg-white rounded-lg shadow-sm border p-6">
+        <h2 class="text-lg font-semibold mb-4">Linked Companies</h2>
+
+        @if($ossProject->companies->count())
+            <div class="space-y-2 mb-6">
+                @foreach($ossProject->companies as $company)
+                    <div class="flex items-center justify-between p-3 bg-gray-50 rounded-lg">
+                        <div>
+                            <span class="font-medium">{{ $company->name }}</span>
+                            <span class="ml-2 px-2 py-0.5 bg-gray-200 text-gray-700 text-xs rounded">{{ str_replace('_', ' ', $company->pivot->relationship_type) }}</span>
+                            @if($company->pivot->notes)
+                                <span class="ml-2 text-sm text-gray-500">{{ $company->pivot->notes }}</span>
+                            @endif
+                        </div>
+                        <form method="POST" action="{{ route('admin.oss-projects.unlink-company', [$ossProject, $company]) }}">
+                            @csrf
+                            @method('DELETE')
+                            <button type="submit" class="text-red-600 hover:text-red-800 text-sm">Unlink</button>
+                        </form>
+                    </div>
+                @endforeach
+            </div>
+        @else
+            <p class="text-gray-500 mb-4">No companies linked yet.</p>
+        @endif
+
+        <form method="POST" action="{{ route('admin.oss-projects.link-company', $ossProject) }}" class="flex flex-col sm:flex-row gap-3">
+            @csrf
+            <select name="company_id" required class="rounded-md border-gray-300 shadow-sm flex-1">
+                <option value="">Select a company...</option>
+                @foreach($companies as $company)
+                    <option value="{{ $company->id }}">{{ $company->name }}</option>
+                @endforeach
+            </select>
+            <select name="relationship_type" required class="rounded-md border-gray-300 shadow-sm">
+                <option value="alternative_to">Alternative to</option>
+                <option value="fork_of">Fork of</option>
+                <option value="built_on">Built on</option>
+                <option value="commercial_version_of">Commercial version of</option>
+            </select>
+            <input type="text" name="notes" placeholder="Notes (optional)" class="rounded-md border-gray-300 shadow-sm">
+            <button type="submit" class="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 whitespace-nowrap">Link Company</button>
+        </form>
+    </div>
+</div>
+@endsection

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -25,6 +25,9 @@
                     <a href="{{ route('companies.compare') }}" class="text-gray-600 hover:text-gray-900">
                         Compare
                     </a>
+                    <a href="{{ route('open-source.index') }}" class="text-gray-600 hover:text-gray-900">
+                        Open Source
+                    </a>
 
                     @auth
                         <div x-data="{ open: false }" class="relative">

--- a/resources/views/open-source/index.blade.php
+++ b/resources/views/open-source/index.blade.php
@@ -1,0 +1,86 @@
+@extends('layouts.app')
+
+@section('title', 'Open Source Projects - StartupGraph')
+
+@section('content')
+<div class="space-y-6">
+    <div>
+        <h1 class="text-2xl font-bold text-gray-900">Open Source Projects</h1>
+        <p class="text-gray-600">{{ $projects->total() }} open-source projects tracked, ranked by GitHub stars</p>
+    </div>
+
+    <form method="GET" action="{{ route('open-source.index') }}" class="bg-white p-4 rounded-lg shadow-sm border">
+        <div class="flex flex-col sm:flex-row gap-4">
+            <div class="flex-1">
+                <input type="text" name="search" value="{{ request('search') }}" placeholder="Search projects..." class="w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500">
+            </div>
+            <div>
+                <select name="language" class="rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500">
+                    <option value="">All Languages</option>
+                    @foreach($languages as $lang)
+                        <option value="{{ $lang }}" {{ request('language') === $lang ? 'selected' : '' }}>{{ $lang }}</option>
+                    @endforeach
+                </select>
+            </div>
+            <label class="flex items-center gap-2 text-sm text-gray-700">
+                <input type="checkbox" name="self_hostable" value="1" {{ request()->boolean('self_hostable') ? 'checked' : '' }} class="rounded border-gray-300">
+                Self-hostable only
+            </label>
+            <button type="submit" class="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700">Filter</button>
+        </div>
+    </form>
+
+    <div class="grid gap-4">
+        @forelse($projects as $project)
+        <div class="bg-white rounded-lg shadow-sm border p-5 hover:shadow-md transition-shadow">
+            <div class="flex items-start justify-between">
+                <div class="flex-1 min-w-0">
+                    <div class="flex items-center gap-3">
+                        <h2 class="text-lg font-semibold text-gray-900">
+                            <a href="{{ $project->github_url }}" target="_blank" class="hover:text-blue-600">{{ $project->name }}</a>
+                        </h2>
+                        @if($project->self_hostable)
+                            <span class="px-2 py-0.5 bg-green-100 text-green-800 text-xs rounded-full font-medium">Self-hostable</span>
+                        @endif
+                    </div>
+                    <p class="text-sm text-gray-500 mt-0.5">{{ $project->github_owner }}/{{ $project->github_repo }}</p>
+                    @if($project->description)
+                        <p class="text-gray-700 mt-2 line-clamp-2">{{ $project->description }}</p>
+                    @endif
+                    @if($project->topics)
+                        <div class="mt-2 flex flex-wrap gap-1">
+                            @foreach(array_slice($project->topics, 0, 6) as $topic)
+                                <span class="px-2 py-0.5 bg-gray-100 text-gray-600 text-xs rounded-full">{{ $topic }}</span>
+                            @endforeach
+                        </div>
+                    @endif
+                </div>
+                <div class="flex items-center gap-4 ml-4 text-sm text-gray-500 shrink-0">
+                    <div class="text-right">
+                        <p class="font-mono font-semibold text-gray-900">{{ number_format($project->stars) }}</p>
+                        <p class="text-xs">stars</p>
+                    </div>
+                    <div class="text-right">
+                        <p class="font-mono">{{ number_format($project->forks) }}</p>
+                        <p class="text-xs">forks</p>
+                    </div>
+                    @if($project->primary_language)
+                        <div class="text-right">
+                            <p class="font-medium text-gray-700">{{ $project->primary_language }}</p>
+                            <p class="text-xs">language</p>
+                        </div>
+                    @endif
+                </div>
+            </div>
+        </div>
+        @empty
+        <div class="bg-white rounded-lg shadow-sm border p-12 text-center text-gray-500">
+            <p class="text-lg">No open-source projects found.</p>
+            <p class="text-sm mt-1">Check back soon — we're importing projects from GitHub.</p>
+        </div>
+        @endforelse
+    </div>
+
+    <div>{{ $projects->links() }}</div>
+</div>
+@endsection

--- a/routes/console.php
+++ b/routes/console.php
@@ -63,6 +63,20 @@ Schedule::command('companies:discover --source=hackernews')
     ->onOneServer()
     ->appendOutputTo(storage_path('logs/companies-discover.log'));
 
+// Nightly OSS project discovery - runs at 5:30am
+Schedule::command('app:discover-oss-projects')
+    ->dailyAt('05:30')
+    ->withoutOverlapping()
+    ->onOneServer()
+    ->appendOutputTo(storage_path('logs/oss-discover.log'));
+
+// Weekly OSS star refresh - runs Sundays at 6:30am
+Schedule::command('app:refresh-oss-stars')
+    ->weeklyOn(0, '06:30')
+    ->withoutOverlapping()
+    ->onOneServer()
+    ->appendOutputTo(storage_path('logs/oss-refresh-stars.log'));
+
 // Daily news fetch - runs at 3am
 Schedule::command('news:fetch')
     ->dailyAt('03:00')

--- a/routes/web.php
+++ b/routes/web.php
@@ -4,7 +4,9 @@ use App\Http\Controllers\CompanyController;
 use App\Http\Controllers\CompareController;
 use App\Http\Controllers\Admin\CompanyController as AdminCompanyController;
 use App\Http\Controllers\PersonController;
+use App\Http\Controllers\OpenSourceController;
 use App\Http\Controllers\ProfileController;
+use App\Http\Controllers\Admin\OssProjectController as AdminOssProjectController;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/', [CompanyController::class, 'index'])->name('home');
@@ -14,6 +16,7 @@ Route::get('/companies/export/csv', [CompanyController::class, 'exportCsv'])->na
 Route::get('/companies/export/json', [CompanyController::class, 'exportJson'])->name('companies.export.json');
 Route::get('/companies/{company}', [CompanyController::class, 'show'])->name('companies.show');
 Route::get('/people/{person}', [PersonController::class, 'show'])->name('people.show');
+Route::get('/open-source', [OpenSourceController::class, 'index'])->name('open-source.index');
 
 // Admin routes
 Route::prefix('admin')->middleware(['throttle:10,1', 'admin.auth'])->name('admin.')->group(function () {
@@ -23,6 +26,11 @@ Route::prefix('admin')->middleware(['throttle:10,1', 'admin.auth'])->name('admin
     Route::get('/companies/{company}/edit', [AdminCompanyController::class, 'edit'])->name('companies.edit');
     Route::put('/companies/{company}', [AdminCompanyController::class, 'update'])->name('companies.update');
     Route::delete('/companies/{company}', [AdminCompanyController::class, 'destroy'])->name('companies.destroy');
+
+    Route::get('/oss-projects', [AdminOssProjectController::class, 'index'])->name('oss-projects.index');
+    Route::get('/oss-projects/{ossProject}', [AdminOssProjectController::class, 'show'])->name('oss-projects.show');
+    Route::post('/oss-projects/{ossProject}/link-company', [AdminOssProjectController::class, 'linkCompany'])->name('oss-projects.link-company');
+    Route::delete('/oss-projects/{ossProject}/unlink-company/{company}', [AdminOssProjectController::class, 'unlinkCompany'])->name('oss-projects.unlink-company');
 });
 
 // Authenticated user routes


### PR DESCRIPTION
## OSS Project Tracking — Phase 1 (#52)

Adds infrastructure for discovering and tracking open-source projects from GitHub, linking them to companies as alternatives/forks/etc.

### What's included

**Data Model:**
- `open_source_projects` table (name, GitHub metadata, stars, forks, language, topics, license, etc.)
- `company_oss_alternatives` pivot table with relationship types (alternative_to, fork_of, built_on, commercial_version_of)
- `OpenSourceProject` model + `Company::ossAlternatives()` relationship

**GitHub Discovery Service:**
- Search repos by topics: self-hosted, open-source-alternative, selfhosted, ai, llm, machine-learning
- Filter: >500 stars, active in last year
- Parse awesome-selfhosted README for additional projects
- Deduplication by github_url
- Supports `GITHUB_TOKEN` env var for higher rate limits

**Artisan Commands:**
- `app:discover-oss-projects` — full discovery run
- `app:refresh-oss-stars` — refresh star/fork counts with rate-limit awareness

**Schedule:**
- Nightly discovery at 5:30am
- Weekly star refresh Sundays at 6:30am

**Views:**
- Admin: list OSS projects, view details, link/unlink companies
- Public: `/open-source` page with search, language filter, self-hostable filter

Closes #52