### PR TITLE
fix: Resolve NewsSearchService test failures (Http facade null)

### DIFF
--- a/tests/Unit/NewsSearchServiceTest.php
+++ b/tests/Unit/NewsSearchServiceTest.php
@@ -3,7 +3,7 @@
 namespace Tests\Unit;
 
 use App\Services\NewsSearchService;
-use PHPUnit\Framework\TestCase;
+use Tests\TestCase;
 
 class NewsSearchServiceTest extends TestCase
 {
@@ -12,7 +12,7 @@ class NewsSearchServiceTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->service = new NewsSearchService();
+        $this->service = app(NewsSearchService::class);
     }
 
     public function test_extract_date_from_valid_url(): void


### PR DESCRIPTION
## Problem
`NewsSearchServiceTest` extended `PHPUnit\Framework\TestCase` directly, so the Laravel application was never bootstrapped. This caused `Http::getFacadeRoot()` to return `null`, which failed the typed property assignment.

## Fix
- Switch to `Tests\TestCase` (Laravel's base test case)
- Use `app()` to resolve `NewsSearchService` from the container

## Result
All 85 tests pass (was 2 failures, 83 passes).