### PR TITLE
feat: expand investor data with profile pages (#22)

### DIFF
--- a/app/Http/Controllers/InvestorController.php
+++ b/app/Http/Controllers/InvestorController.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Investor;
+use Illuminate\Http\Request;
+
+class InvestorController extends Controller
+{
+    public function index(Request $request)
+    {
+        $query = Investor::query()
+            ->withCount('fundingRounds');
+
+        if ($search = $request->get('search')) {
+            $escaped = str_replace(['%', '_'], ['\%', '\_'], $search);
+            $query->where(function ($q) use ($escaped) {
+                $q->where('name', 'like', "%{$escaped}%")
+                  ->orWhere('description', 'like', "%{$escaped}%");
+            });
+        }
+
+        if ($type = $request->get('type')) {
+            $query->where('type', $type);
+        }
+
+        $sortField = $request->get('sort', 'name');
+        $sortDirection = $request->get('direction', 'asc');
+        $allowedSorts = ['name', 'type', 'portfolio_count', 'funding_rounds_count'];
+        if (in_array($sortField, $allowedSorts)) {
+            $query->orderBy($sortField, $sortDirection === 'desc' ? 'desc' : 'asc');
+        }
+
+        $investors = $query->paginate(50)->withQueryString();
+        $types = Investor::distinct()->whereNotNull('type')->pluck('type')->sort()->values();
+
+        return view('investors.index', compact('investors', 'types'));
+    }
+
+    public function show(Investor $investor)
+    {
+        $investor->load(['fundingRounds' => function ($q) {
+            $q->with('company')->orderByDesc('announced_date');
+        }]);
+
+        $companies = $investor->fundingRounds
+            ->pluck('company')
+            ->unique('id')
+            ->sortBy('name')
+            ->values();
+
+        $totalInvested = $investor->fundingRounds->sum('amount');
+
+        return view('investors.show', compact('investor', 'companies', 'totalInvested'));
+    }
+}

--- a/app/Models/Investor.php
+++ b/app/Models/Investor.php
@@ -15,7 +15,29 @@ class Investor extends Model
         'type',
         'website',
         'description',
+        'portfolio_count',
     ];
+
+    public function companies()
+    {
+        return $this->fundingRounds()
+            ->with('company')
+            ->get()
+            ->pluck('company')
+            ->unique('id');
+    }
+
+    public function getTypeLabelAttribute(): string
+    {
+        return match($this->type) {
+            'vc' => 'Venture Capital',
+            'angel' => 'Angel Investor',
+            'corporate' => 'Corporate VC',
+            'accelerator' => 'Accelerator',
+            'pe' => 'Private Equity',
+            default => $this->type ?? 'Unknown',
+        };
+    }
 
     public function fundingRounds(): BelongsToMany
     {

--- a/database/migrations/2026_02_16_200000_add_portfolio_count_to_investors_table.php
+++ b/database/migrations/2026_02_16_200000_add_portfolio_count_to_investors_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('investors', function (Blueprint $table) {
+            $table->unsignedInteger('portfolio_count')->nullable()->after('description');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('investors', function (Blueprint $table) {
+            $table->dropColumn('portfolio_count');
+        });
+    }
+};

--- a/database/seeders/InvestorSeeder.php
+++ b/database/seeders/InvestorSeeder.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Investor;
+use App\Models\FundingRound;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Str;
+
+class InvestorSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $investors = [
+            ['name' => 'Sequoia Capital', 'type' => 'vc', 'website' => 'https://www.sequoiacap.com', 'description' => 'Legendary Silicon Valley venture capital firm backing iconic companies from Apple to Stripe.', 'portfolio_count' => 1500],
+            ['name' => 'Andreessen Horowitz', 'type' => 'vc', 'website' => 'https://a16z.com', 'description' => 'Software-focused VC firm known for bold bets on transformative technology companies.', 'portfolio_count' => 1000],
+            ['name' => 'Accel', 'type' => 'vc', 'website' => 'https://www.accel.com', 'description' => 'Global venture capital firm investing in seed through growth stage technology companies.', 'portfolio_count' => 800],
+            ['name' => 'Founders Fund', 'type' => 'vc', 'website' => 'https://foundersfund.com', 'description' => 'Peter Thiel-founded VC firm investing in revolutionary technology companies.', 'portfolio_count' => 300],
+            ['name' => 'Lightspeed Venture Partners', 'type' => 'vc', 'website' => 'https://lsvp.com', 'description' => 'Multi-stage VC firm with global presence investing in enterprise and consumer tech.', 'portfolio_count' => 500],
+            ['name' => 'Khosla Ventures', 'type' => 'vc', 'website' => 'https://www.khoslaventures.com', 'description' => 'Deep tech and climate-focused VC firm founded by Sun Microsystems co-founder.', 'portfolio_count' => 400],
+            ['name' => 'General Catalyst', 'type' => 'vc', 'website' => 'https://www.generalcatalyst.com', 'description' => 'Venture capital firm focused on early and growth stage investments in technology.', 'portfolio_count' => 600],
+            ['name' => 'Index Ventures', 'type' => 'vc', 'website' => 'https://www.indexventures.com', 'description' => 'European-founded global VC backing companies from seed to IPO.', 'portfolio_count' => 400],
+            ['name' => 'Tiger Global Management', 'type' => 'vc', 'website' => 'https://www.tigerglobal.com', 'description' => 'Crossover fund investing in public and private technology companies globally.', 'portfolio_count' => 350],
+            ['name' => 'Coatue Management', 'type' => 'vc', 'website' => 'https://www.coatue.com', 'description' => 'Technology-focused investment firm spanning public and private markets.', 'portfolio_count' => 300],
+            ['name' => 'Y Combinator', 'type' => 'accelerator', 'website' => 'https://www.ycombinator.com', 'description' => 'Premier startup accelerator that has funded Airbnb, Stripe, DoorDash, and 4000+ startups.', 'portfolio_count' => 4000],
+            ['name' => 'GV (Google Ventures)', 'type' => 'corporate', 'website' => 'https://www.gv.com', 'description' => 'Google parent Alphabet\'s venture capital arm investing across life science and technology.', 'portfolio_count' => 500],
+            ['name' => 'Intel Capital', 'type' => 'corporate', 'website' => 'https://www.intelcapital.com', 'description' => 'Intel\'s global investment organization backing disruptive technology companies.', 'portfolio_count' => 350],
+            ['name' => 'Salesforce Ventures', 'type' => 'corporate', 'website' => 'https://www.salesforceventures.com', 'description' => 'Strategic investment arm of Salesforce focused on enterprise cloud ecosystem.', 'portfolio_count' => 400],
+            ['name' => 'Naval Ravikant', 'type' => 'angel', 'website' => 'https://nav.al', 'description' => 'Prolific angel investor and AngelList co-founder who has backed 200+ startups.', 'portfolio_count' => 200],
+            ['name' => 'Ron Conway', 'type' => 'angel', 'website' => null, 'description' => 'Legendary Silicon Valley angel investor known as the godfather of angel investing.', 'portfolio_count' => 700],
+            ['name' => 'Elad Gil', 'type' => 'angel', 'website' => 'https://eladgil.com', 'description' => 'Entrepreneur and angel investor, author of High Growth Handbook.', 'portfolio_count' => 150],
+            ['name' => 'NEA (New Enterprise Associates)', 'type' => 'vc', 'website' => 'https://www.nea.com', 'description' => 'One of the largest and most active VCs globally, investing across technology and healthcare.', 'portfolio_count' => 1000],
+            ['name' => 'Benchmark', 'type' => 'vc', 'website' => 'https://www.benchmark.com', 'description' => 'Elite early-stage VC firm known for equal partnership and iconic investments.', 'portfolio_count' => 300],
+            ['name' => 'Greylock Partners', 'type' => 'vc', 'website' => 'https://greylock.com', 'description' => 'Storied VC firm specializing in early-stage consumer and enterprise investments.', 'portfolio_count' => 400],
+        ];
+
+        foreach ($investors as $data) {
+            Investor::updateOrCreate(
+                ['slug' => Str::slug($data['name'])],
+                array_merge($data, ['slug' => Str::slug($data['name'])])
+            );
+        }
+
+        // Link some investors to existing funding rounds
+        $allInvestors = Investor::all();
+        $rounds = FundingRound::all();
+
+        if ($rounds->count() && $allInvestors->count()) {
+            foreach ($rounds as $round) {
+                // Skip if already has investors
+                if ($round->investors()->count()) continue;
+
+                // Randomly assign 1-3 investors
+                $count = rand(1, 3);
+                $selected = $allInvestors->random(min($count, $allInvestors->count()));
+                foreach ($selected as $i => $investor) {
+                    $round->investors()->attach($investor->id, ['is_lead' => $i === 0]);
+                }
+            }
+        }
+    }
+}

--- a/resources/views/companies/show.blade.php
+++ b/resources/views/companies/show.blade.php
@@ -191,7 +191,9 @@
                                     </p>
                                     @if($round->investors->count())
                                         <p class="text-sm text-gray-500">
-                                            {{ $round->investors->pluck('name')->join(', ') }}
+                                            @foreach($round->investors as $inv)
+                                                <a href="{{ route('investors.show', $inv) }}" class="text-blue-600 hover:underline">{{ $inv->name }}</a>@if(!$loop->last), @endif
+                                            @endforeach
                                         </p>
                                     @endif
                                 </div>

--- a/resources/views/investors/index.blade.php
+++ b/resources/views/investors/index.blade.php
@@ -1,0 +1,78 @@
+@extends('layouts.app')
+
+@section('title', 'Investors - StartupGraph')
+
+@section('content')
+<div class="space-y-6">
+    <div>
+        <h1 class="text-2xl font-bold text-gray-900">Investors</h1>
+        <p class="text-gray-600">{{ $investors->total() }} investors tracked</p>
+    </div>
+
+    <form method="GET" action="{{ route('investors.index') }}" class="bg-white p-4 rounded-lg shadow-sm border">
+        <div class="flex flex-col sm:flex-row gap-4">
+            <div class="flex-1">
+                <input type="text" name="search" value="{{ request('search') }}" placeholder="Search investors..."
+                    class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500">
+            </div>
+            <div class="sm:w-48">
+                <select name="type" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500">
+                    <option value="">All Types</option>
+                    @foreach($types as $type)
+                        <option value="{{ $type }}" {{ request('type') == $type ? 'selected' : '' }}>
+                            {{ ucfirst($type) }}
+                        </option>
+                    @endforeach
+                </select>
+            </div>
+            <button type="submit" class="px-6 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700">Search</button>
+        </div>
+    </form>
+
+    <div class="bg-white rounded-lg shadow-sm border overflow-hidden">
+        <table class="min-w-full divide-y divide-gray-200">
+            <thead class="bg-gray-50">
+                <tr>
+                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Name</th>
+                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Type</th>
+                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Portfolio</th>
+                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Rounds</th>
+                </tr>
+            </thead>
+            <tbody class="bg-white divide-y divide-gray-200">
+                @forelse($investors as $investor)
+                    <tr class="hover:bg-gray-50">
+                        <td class="px-6 py-4">
+                            <a href="{{ route('investors.show', $investor) }}" class="font-medium text-blue-600 hover:underline">
+                                {{ $investor->name }}
+                            </a>
+                            @if($investor->description)
+                                <p class="text-sm text-gray-500 truncate max-w-md">{{ $investor->description }}</p>
+                            @endif
+                        </td>
+                        <td class="px-6 py-4 text-sm text-gray-600">
+                            @if($investor->type)
+                                <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800">
+                                    {{ $investor->type_label }}
+                                </span>
+                            @endif
+                        </td>
+                        <td class="px-6 py-4 text-sm text-gray-600">
+                            {{ $investor->portfolio_count ?? '—' }}
+                        </td>
+                        <td class="px-6 py-4 text-sm text-gray-600">
+                            {{ $investor->funding_rounds_count }}
+                        </td>
+                    </tr>
+                @empty
+                    <tr>
+                        <td colspan="4" class="px-6 py-8 text-center text-gray-500">No investors found.</td>
+                    </tr>
+                @endforelse
+            </tbody>
+        </table>
+    </div>
+
+    <div class="mt-4">{{ $investors->links() }}</div>
+</div>
+@endsection

--- a/resources/views/investors/show.blade.php
+++ b/resources/views/investors/show.blade.php
@@ -1,0 +1,116 @@
+@extends('layouts.app')
+
+@section('title', $investor->name . ' - StartupGraph')
+
+@section('content')
+<div class="space-y-6">
+    <div class="flex items-center gap-2 text-sm">
+        <a href="{{ route('investors.index') }}" class="text-blue-600 hover:underline">Investors</a>
+        <span class="text-gray-400">/</span>
+        <span class="text-gray-600">{{ $investor->name }}</span>
+    </div>
+
+    <div class="bg-white rounded-lg shadow-sm border p-6">
+        <div class="flex flex-col md:flex-row md:items-start md:justify-between gap-4">
+            <div>
+                <h1 class="text-3xl font-bold text-gray-900">{{ $investor->name }}</h1>
+                @if($investor->type)
+                    <span class="inline-flex items-center px-3 py-1 mt-2 rounded-full text-sm font-medium bg-blue-100 text-blue-800">
+                        {{ $investor->type_label }}
+                    </span>
+                @endif
+            </div>
+            @if($investor->website)
+                <a href="{{ $investor->website }}" target="_blank" rel="noopener noreferrer"
+                   class="inline-flex items-center px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors">
+                    Visit Website
+                    <svg class="w-4 h-4 ml-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"/>
+                    </svg>
+                </a>
+            @endif
+        </div>
+
+        @if($investor->description)
+            <p class="text-gray-600 mt-4 leading-relaxed">{{ $investor->description }}</p>
+        @endif
+
+        <div class="grid grid-cols-2 md:grid-cols-3 gap-6 mt-6 pt-6 border-t">
+            <div>
+                <p class="text-sm text-gray-500">Portfolio Companies</p>
+                <p class="text-lg font-semibold text-gray-900">{{ $companies->count() }}</p>
+            </div>
+            <div>
+                <p class="text-sm text-gray-500">Funding Rounds</p>
+                <p class="text-lg font-semibold text-gray-900">{{ $investor->fundingRounds->count() }}</p>
+            </div>
+            <div>
+                <p class="text-sm text-gray-500">Total Invested</p>
+                <p class="text-lg font-semibold text-gray-900">
+                    @if($totalInvested >= 1000000000)
+                        ${{ number_format($totalInvested / 1000000000, 1) }}B
+                    @elseif($totalInvested >= 1000000)
+                        ${{ number_format($totalInvested / 1000000, 0) }}M
+                    @else
+                        ${{ number_format($totalInvested) }}
+                    @endif
+                </p>
+            </div>
+        </div>
+    </div>
+
+    @if($companies->count())
+        <div class="bg-white rounded-lg shadow-sm border p-6">
+            <h2 class="text-xl font-bold text-gray-900 mb-4">Portfolio Companies</h2>
+            <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+                @foreach($companies as $company)
+                    <a href="{{ route('companies.show', $company) }}" class="p-4 bg-gray-50 rounded-lg hover:bg-gray-100 transition-colors">
+                        <p class="font-semibold text-gray-900">{{ $company->name }}</p>
+                        @if($company->description)
+                            <p class="text-sm text-gray-500 mt-1 line-clamp-2">{{ $company->description }}</p>
+                        @endif
+                        @if($company->city || $company->country)
+                            <p class="text-xs text-gray-400 mt-2">{{ collect([$company->city, $company->country])->filter()->join(', ') }}</p>
+                        @endif
+                    </a>
+                @endforeach
+            </div>
+        </div>
+    @endif
+
+    @if($investor->fundingRounds->count())
+        <div class="bg-white rounded-lg shadow-sm border p-6">
+            <h2 class="text-xl font-bold text-gray-900 mb-4">Investment History</h2>
+            <div class="space-y-3">
+                @foreach($investor->fundingRounds as $round)
+                    <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between p-3 bg-gray-50 rounded-lg">
+                        <div>
+                            <a href="{{ route('companies.show', $round->company) }}" class="font-semibold text-blue-600 hover:underline">
+                                {{ $round->company->name }}
+                            </a>
+                            <p class="text-sm text-gray-500">
+                                {{ ucfirst(str_replace('_', ' ', $round->round_type ?? 'Round')) }}
+                                @if($round->pivot->is_lead) <span class="text-green-600 font-medium">• Lead</span> @endif
+                            </p>
+                        </div>
+                        <div class="text-right mt-2 sm:mt-0">
+                            @if($round->amount)
+                                <p class="font-semibold text-gray-900">
+                                    @if($round->amount >= 1000000000)
+                                        ${{ number_format($round->amount / 1000000000, 1) }}B
+                                    @else
+                                        ${{ number_format($round->amount / 1000000, 0) }}M
+                                    @endif
+                                </p>
+                            @endif
+                            @if($round->announced_date)
+                                <p class="text-sm text-gray-500">{{ $round->announced_date->format('M Y') }}</p>
+                            @endif
+                        </div>
+                    </div>
+                @endforeach
+            </div>
+        </div>
+    @endif
+</div>
+@endsection

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -25,6 +25,9 @@
                     <a href="{{ route('companies.compare') }}" class="text-gray-600 hover:text-gray-900">
                         Compare
                     </a>
+                    <a href="{{ route('investors.index') }}" class="text-gray-600 hover:text-gray-900">
+                        Investors
+                    </a>
                     <a href="{{ route('open-source.index') }}" class="text-gray-600 hover:text-gray-900">
                         Open Source
                     </a>

--- a/routes/web.php
+++ b/routes/web.php
@@ -7,6 +7,7 @@ use App\Http\Controllers\SubmissionController;
 use App\Http\Controllers\Admin\CompanyController as AdminCompanyController;
 use App\Http\Controllers\Admin\SubmissionController as AdminSubmissionController;
 use App\Http\Controllers\PersonController;
+use App\Http\Controllers\InvestorController;
 use App\Http\Controllers\OpenSourceController;
 use App\Http\Controllers\ProfileController;
 use App\Http\Controllers\Admin\OssProjectController as AdminOssProjectController;
@@ -20,6 +21,8 @@ Route::get('/companies/export/csv', [CompanyController::class, 'exportCsv'])->na
 Route::get('/companies/export/json', [CompanyController::class, 'exportJson'])->name('companies.export.json');
 Route::get('/companies/{company}', [CompanyController::class, 'show'])->name('companies.show');
 Route::get('/people/{person}', [PersonController::class, 'show'])->name('people.show');
+Route::get('/investors', [InvestorController::class, 'index'])->name('investors.index');
+Route::get('/investors/{investor}', [InvestorController::class, 'show'])->name('investors.show');
 Route::get('/open-source', [OpenSourceController::class, 'index'])->name('open-source.index');
 
 Route::get('/submit', [SubmissionController::class, 'create'])->name('submissions.create');


### PR DESCRIPTION
## Changes
- Add portfolio_count column to investors table
- Create InvestorController with index/show, search & filter by type
- Investor profile pages showing portfolio companies and investment history
- Seed 20 real investors (VCs, angels, corporate VCs, accelerators)
- Link investor names in company funding rounds to their profile pages
- Add Investors to main navigation

Closes #22