### PR TITLE
feat: saved searches & watchlists (#31)

### DIFF
--- a/app/Http/Controllers/SavedSearchController.php
+++ b/app/Http/Controllers/SavedSearchController.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\SavedSearch;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class SavedSearchController extends Controller
+{
+    public function index()
+    {
+        $savedSearches = Auth::user()->savedSearches()
+            ->orderByDesc('updated_at')
+            ->get();
+
+        return view('saved-searches.index', compact('savedSearches'));
+    }
+
+    public function store(Request $request)
+    {
+        $request->validate([
+            'name' => 'nullable|string|max:255',
+            'notify_on_new' => 'boolean',
+        ]);
+
+        $filters = [];
+        foreach (['category', 'country', 'funded_recent', 'funded_after', 'funded_before'] as $key) {
+            if ($request->filled($key)) {
+                $filters[$key] = $request->get($key);
+            }
+        }
+
+        $savedSearch = Auth::user()->savedSearches()->create([
+            'name' => $request->get('name'),
+            'query' => $request->get('search'),
+            'filters_json' => !empty($filters) ? $filters : null,
+            'notify_on_new' => $request->boolean('notify_on_new', false),
+        ]);
+
+        if ($request->wantsJson()) {
+            return response()->json(['id' => $savedSearch->id, 'message' => 'Search saved'], 201);
+        }
+
+        return back()->with('success', 'Search saved to your watchlist!');
+    }
+
+    public function update(Request $request, SavedSearch $savedSearch)
+    {
+        $this->authorize('update', $savedSearch);
+
+        $request->validate([
+            'name' => 'nullable|string|max:255',
+            'notify_on_new' => 'boolean',
+        ]);
+
+        $savedSearch->update($request->only(['name', 'notify_on_new']));
+
+        return back()->with('success', 'Saved search updated.');
+    }
+
+    public function destroy(SavedSearch $savedSearch)
+    {
+        $this->authorize('delete', $savedSearch);
+
+        $savedSearch->delete();
+
+        if (request()->wantsJson()) {
+            return response()->json(['message' => 'Deleted']);
+        }
+
+        return back()->with('success', 'Saved search removed.');
+    }
+}

--- a/app/Models/SavedSearch.php
+++ b/app/Models/SavedSearch.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class SavedSearch extends Model
+{
+    protected $fillable = [
+        'user_id',
+        'name',
+        'query',
+        'filters_json',
+        'notify_on_new',
+        'last_notified_at',
+        'last_result_count',
+    ];
+
+    protected $casts = [
+        'filters_json' => 'array',
+        'notify_on_new' => 'boolean',
+        'last_notified_at' => 'datetime',
+    ];
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    /**
+     * Build a display name from query/filters if no name set.
+     */
+    public function getDisplayNameAttribute(): string
+    {
+        if ($this->name) return $this->name;
+
+        $parts = [];
+        if ($this->query) $parts[] = '"' . $this->query . '"';
+        if ($filters = $this->filters_json) {
+            if (!empty($filters['category'])) $parts[] = $filters['category'];
+            if (!empty($filters['country'])) $parts[] = $filters['country'];
+        }
+
+        return $parts ? implode(' · ', $parts) : 'All companies';
+    }
+
+    /**
+     * Get the URL to re-run this search.
+     */
+    public function getSearchUrlAttribute(): string
+    {
+        $params = [];
+        if ($this->query) $params['search'] = $this->query;
+        if ($filters = $this->filters_json) {
+            foreach (['category', 'country', 'funded_recent', 'funded_after', 'funded_before'] as $key) {
+                if (!empty($filters[$key])) $params[$key] = $filters[$key];
+            }
+        }
+        return route('companies.index', $params);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -38,6 +38,11 @@ class User extends Authenticatable
      *
      * @return array<string, string>
      */
+    public function savedSearches()
+    {
+        return $this->hasMany(SavedSearch::class);
+    }
+
     protected function casts(): array
     {
         return [

--- a/app/Policies/SavedSearchPolicy.php
+++ b/app/Policies/SavedSearchPolicy.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\SavedSearch;
+use App\Models\User;
+
+class SavedSearchPolicy
+{
+    public function update(User $user, SavedSearch $savedSearch): bool
+    {
+        return $user->id === $savedSearch->user_id;
+    }
+
+    public function delete(User $user, SavedSearch $savedSearch): bool
+    {
+        return $user->id === $savedSearch->user_id;
+    }
+}

--- a/database/migrations/2026_02_16_202000_create_saved_searches_table.php
+++ b/database/migrations/2026_02_16_202000_create_saved_searches_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('saved_searches', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->onDelete('cascade');
+            $table->string('name')->nullable();
+            $table->string('query')->nullable();
+            $table->json('filters_json')->nullable();
+            $table->boolean('notify_on_new')->default(false);
+            $table->timestamp('last_notified_at')->nullable();
+            $table->unsignedInteger('last_result_count')->default(0);
+            $table->timestamps();
+
+            $table->index('user_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('saved_searches');
+    }
+};

--- a/resources/views/companies/index.blade.php
+++ b/resources/views/companies/index.blade.php
@@ -16,6 +16,26 @@
             <a href="{{ route('companies.export.json', request()->query()) }}" class="inline-flex items-center px-3 py-1.5 bg-white border border-gray-300 rounded-md text-sm text-gray-700 hover:bg-gray-50">
                 Export JSON
             </a>
+            @auth
+                @if(request()->hasAny(['search', 'category', 'country', 'funded_recent', 'funded_after', 'funded_before']))
+                    <form method="POST" action="{{ route('saved-searches.store') }}" class="inline">
+                        @csrf
+                        @foreach(['search', 'category', 'country', 'funded_recent', 'funded_after', 'funded_before'] as $param)
+                            @if(request($param))
+                                <input type="hidden" name="{{ $param }}" value="{{ request($param) }}">
+                            @endif
+                        @endforeach
+                        <input type="hidden" name="notify_on_new" value="1">
+                        <button type="submit" class="inline-flex items-center px-3 py-1.5 bg-yellow-50 border border-yellow-300 rounded-md text-sm text-yellow-800 hover:bg-yellow-100">
+                            <svg class="w-4 h-4 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9"/></svg>
+                            Watch
+                        </button>
+                    </form>
+                @endif
+                <a href="{{ route('saved-searches.index') }}" class="inline-flex items-center px-3 py-1.5 bg-white border border-gray-300 rounded-md text-sm text-gray-700 hover:bg-gray-50">
+                    My Watches
+                </a>
+            @endauth
         </div>
     </div>
 

--- a/resources/views/saved-searches/index.blade.php
+++ b/resources/views/saved-searches/index.blade.php
@@ -1,0 +1,68 @@
+@extends('layouts.app')
+
+@section('title', 'Saved Searches - StartupGraph')
+
+@section('content')
+<div class="space-y-6">
+    <div>
+        <h1 class="text-2xl font-bold text-gray-900">Saved Searches & Watchlists</h1>
+        <p class="text-gray-600">Your saved search queries. We'll notify you when new companies match.</p>
+    </div>
+
+    @if(session('success'))
+        <div class="bg-green-50 border border-green-200 text-green-700 px-4 py-3 rounded-lg">
+            {{ session('success') }}
+        </div>
+    @endif
+
+    @if($savedSearches->count())
+        <div class="space-y-4">
+            @foreach($savedSearches as $search)
+                <div class="bg-white rounded-lg shadow-sm border p-4 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+                    <div>
+                        <a href="{{ $search->search_url }}" class="font-semibold text-blue-600 hover:underline text-lg">
+                            {{ $search->display_name }}
+                        </a>
+                        <div class="flex items-center gap-3 mt-1 text-sm text-gray-500">
+                            @if($search->notify_on_new)
+                                <span class="inline-flex items-center gap-1 text-green-600">
+                                    <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 20 20"><path d="M10 2a6 6 0 00-6 6v3.586l-.707.707A1 1 0 004 14h12a1 1 0 00.707-1.707L16 11.586V8a6 6 0 00-6-6z"/><path d="M10 18a3 3 0 01-3-3h6a3 3 0 01-3 3z"/></svg>
+                                    Notifications on
+                                </span>
+                            @else
+                                <span class="text-gray-400">Notifications off</span>
+                            @endif
+                            <span>Saved {{ $search->created_at->diffForHumans() }}</span>
+                        </div>
+                    </div>
+                    <div class="flex items-center gap-2">
+                        <a href="{{ $search->search_url }}" class="px-3 py-1.5 bg-blue-50 text-blue-700 rounded-md text-sm hover:bg-blue-100">
+                            Run Search
+                        </a>
+                        <form method="POST" action="{{ route('saved-searches.update', $search) }}">
+                            @csrf
+                            @method('PATCH')
+                            <input type="hidden" name="notify_on_new" value="{{ $search->notify_on_new ? '0' : '1' }}">
+                            <button type="submit" class="px-3 py-1.5 bg-gray-50 text-gray-700 rounded-md text-sm hover:bg-gray-100">
+                                {{ $search->notify_on_new ? 'Mute' : 'Notify' }}
+                            </button>
+                        </form>
+                        <form method="POST" action="{{ route('saved-searches.destroy', $search) }}" onsubmit="return confirm('Remove this saved search?')">
+                            @csrf
+                            @method('DELETE')
+                            <button type="submit" class="px-3 py-1.5 bg-red-50 text-red-700 rounded-md text-sm hover:bg-red-100">
+                                Remove
+                            </button>
+                        </form>
+                    </div>
+                </div>
+            @endforeach
+        </div>
+    @else
+        <div class="bg-white rounded-lg shadow-sm border p-8 text-center">
+            <p class="text-gray-500 mb-4">No saved searches yet.</p>
+            <a href="{{ route('companies.index') }}" class="text-blue-600 hover:underline">Search companies</a> and click "Watch this search" to save it.
+        </div>
+    @endif
+</div>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -49,6 +49,11 @@ Route::middleware('auth')->group(function () {
     Route::get('/profile', [ProfileController::class, 'edit'])->name('profile.edit');
     Route::patch('/profile', [ProfileController::class, 'update'])->name('profile.update');
     Route::delete('/profile', [ProfileController::class, 'destroy'])->name('profile.destroy');
+
+    Route::get('/saved-searches', [\App\Http\Controllers\SavedSearchController::class, 'index'])->name('saved-searches.index');
+    Route::post('/saved-searches', [\App\Http\Controllers\SavedSearchController::class, 'store'])->name('saved-searches.store');
+    Route::patch('/saved-searches/{savedSearch}', [\App\Http\Controllers\SavedSearchController::class, 'update'])->name('saved-searches.update');
+    Route::delete('/saved-searches/{savedSearch}', [\App\Http\Controllers\SavedSearchController::class, 'destroy'])->name('saved-searches.destroy');
 });
 
 require __DIR__.'/auth.php';


### PR DESCRIPTION
## Changes
- Create saved_searches table with user_id, query, filters_json, notify_on_new
- SavedSearch model with display name generation and search URL builder
- SavedSearchController with full CRUD
- Authorization via SavedSearchPolicy (users can only manage their own)
- 'Watch' button appears on company search results when filters are active
- Saved searches management page at /saved-searches with run/mute/remove actions
- 'My Watches' quick link on companies index for authenticated users

Closes #31