### PR TITLE
Add OpenCorporates, Companies House, and Wikipedia unicorn importers

### DIFF
--- a/app/Console/Commands/BulkImportCompanies.php
+++ b/app/Console/Commands/BulkImportCompanies.php
@@ -2,20 +2,25 @@
 
 namespace App\Console\Commands;
 
+use App\Services\BulkImport\CompaniesHouseCsvImporter;
 use App\Services\BulkImport\CrunchbaseCsvImporter;
 use App\Services\BulkImport\EdgarBulkImporter;
+use App\Services\BulkImport\OpenCorporatesBulkImporter;
 use App\Services\BulkImport\ProductHuntBulkImporter;
+use App\Services\BulkImport\WikipediaUnicornImporter;
 use App\Services\BulkImport\YCBulkImporter;
 use Illuminate\Console\Command;
 
 class BulkImportCompanies extends Command
 {
     protected $signature = 'companies:bulk-import
-        {--source= : Import source (yc, crunchbase, producthunt, edgar)}
-        {--file= : CSV file path (required for crunchbase)}
+        {--source= : Import source (yc, crunchbase, producthunt, edgar, opencorporates, companies-house, wikipedia)}
+        {--file= : CSV file path (required for crunchbase, optional for companies-house)}
         {--all : Run all sources}
         {--resume : Resume from last checkpoint}
-        {--max-pages=500 : Maximum pages to fetch (API sources)}';
+        {--max-pages=500 : Maximum pages to fetch (API sources)}
+        {--min-year=2015 : Minimum incorporation year (companies-house)}
+        {--tech-only : Only import tech/startup companies (companies-house, default: true)}';
 
     protected $description = 'Bulk import companies from various data sources';
 
@@ -24,6 +29,9 @@ class BulkImportCompanies extends Command
         'crunchbase' => CrunchbaseCsvImporter::class,
         'producthunt' => ProductHuntBulkImporter::class,
         'edgar' => EdgarBulkImporter::class,
+        'opencorporates' => OpenCorporatesBulkImporter::class,
+        'companies-house' => CompaniesHouseCsvImporter::class,
+        'wikipedia' => WikipediaUnicornImporter::class,
     ];
 
     public function handle(): int
@@ -83,6 +91,15 @@ class BulkImportCompanies extends Command
                 throw new \RuntimeException('--file is required for crunchbase source');
             }
             $options['file'] = $file;
+        }
+
+        if ($source === 'companies-house') {
+            $file = $this->option('file');
+            if ($file) {
+                $options['file'] = $file;
+            }
+            $options['min_year'] = (int) $this->option('min-year');
+            $options['tech_only'] = $this->option('tech-only') !== false;
         }
 
         if ($this->option('resume')) {

--- a/app/Services/BulkImport/CompaniesHouseCsvImporter.php
+++ b/app/Services/BulkImport/CompaniesHouseCsvImporter.php
@@ -1,0 +1,270 @@
+<?php
+
+namespace App\Services\BulkImport;
+
+use Illuminate\Support\Facades\Log;
+
+class CompaniesHouseCsvImporter extends BaseBulkImporter
+{
+    private const DOWNLOAD_URL = 'https://download.companieshouse.gov.uk/BasicCompanyDataAsOneFile-%s.zip';
+
+    // SIC codes that indicate tech/startup companies
+    private const TECH_SIC_PREFIXES = [
+        '58' => 'enterprise',      // Publishing (software publishing)
+        '59' => 'consumer',        // Motion picture / video
+        '60' => 'consumer',        // Broadcasting
+        '61' => 'enterprise',      // Telecommunications
+        '62' => 'enterprise',      // Computer programming, consultancy
+        '63' => 'enterprise',      // Information service activities
+        '64' => 'fintech',         // Financial service activities
+        '65' => 'fintech',         // Insurance
+        '66' => 'fintech',         // Auxiliary financial services
+        '70' => 'enterprise',      // Head offices / management consultancy
+        '71' => 'enterprise',      // Architecture / engineering / technical
+        '72' => 'ai_ml',           // Scientific research and development
+        '74' => 'enterprise',      // Other professional, scientific, technical
+        '85' => 'enterprise',      // Education
+        '86' => 'healthcare',      // Human health activities
+        '21' => 'healthcare',      // Pharma
+        '26' => 'robotics',        // Computer/electronic/optical products
+    ];
+
+    public function source(): string
+    {
+        return 'companies-house';
+    }
+
+    public function import(array $options = []): void
+    {
+        $filePath = $options['file'] ?? null;
+        $techOnly = $options['tech_only'] ?? true;
+        $minIncorporationYear = $options['min_year'] ?? 2015;
+        $resumeOffset = $options['resume_from'] ?? 0;
+
+        if (!$filePath) {
+            $filePath = $this->downloadCsv();
+        }
+
+        if (!file_exists($filePath)) {
+            throw new \RuntimeException("CSV file not found: {$filePath}");
+        }
+
+        Log::info("Companies House CSV import starting", [
+            'file' => $filePath,
+            'tech_only' => $techOnly,
+            'min_year' => $minIncorporationYear,
+        ]);
+
+        $handle = fopen($filePath, 'r');
+        if (!$handle) {
+            throw new \RuntimeException("Cannot open CSV: {$filePath}");
+        }
+
+        // Read and normalize header
+        $header = fgetcsv($handle);
+        if (!$header) {
+            fclose($handle);
+            throw new \RuntimeException("Empty CSV file");
+        }
+
+        // Companies House headers use spaces and dots
+        $header = array_map(function ($h) {
+            return strtolower(trim(str_replace(' ', '', $h)));
+        }, $header);
+
+        $line = 0;
+
+        while (($row = fgetcsv($handle)) !== false) {
+            $line++;
+
+            if ($line <= $resumeOffset) continue;
+
+            if (count($row) !== count($header)) continue;
+
+            $data = @array_combine($header, $row);
+            if (!$data) continue;
+
+            // Filter by incorporation date
+            $incDate = $data['incorporationdate'] ?? '';
+            if ($incDate && $minIncorporationYear) {
+                $year = (int) substr($incDate, 6, 4); // DD/MM/YYYY format
+                if (!$year) {
+                    $year = (int) substr($incDate, 0, 4); // YYYY-MM-DD format
+                }
+                if ($year > 0 && $year < $minIncorporationYear) continue;
+            }
+
+            // Filter by SIC code if tech_only
+            if ($techOnly) {
+                $sicCodes = $this->extractSicCodes($data);
+                $category = $this->categorizeBySic($sicCodes);
+                if (!$category) continue;
+            }
+
+            $this->importRow($data, $category ?? null);
+
+            if ($line % 10000 === 0) {
+                $this->importLog->update([
+                    'last_offset' => (string) $line,
+                    'total_processed' => $this->processed,
+                    'companies_created' => $this->created,
+                ]);
+                Log::info("Companies House CSV: scanned {$line} rows, {$this->created} created");
+            }
+        }
+
+        fclose($handle);
+        Log::info("Companies House CSV import complete", $this->getStats());
+    }
+
+    private function importRow(array $data, ?string $category): void
+    {
+        $name = $data['companyname'] ?? '';
+        if (!$name || !trim($name)) return;
+
+        // Clean ALL CAPS names
+        if ($name === strtoupper($name) && strlen($name) > 3) {
+            $name = ucwords(strtolower($name));
+        }
+
+        $status = $this->mapCompaniesHouseStatus($data['companystatus'] ?? '');
+
+        // Parse incorporation date (DD/MM/YYYY or YYYY-MM-DD)
+        $foundedDate = null;
+        $incDate = $data['incorporationdate'] ?? '';
+        if ($incDate) {
+            if (preg_match('/^(\d{2})\/(\d{2})\/(\d{4})$/', $incDate, $m)) {
+                $foundedDate = "{$m[3]}-{$m[2]}-{$m[1]}";
+            } elseif (preg_match('/^\d{4}-\d{2}-\d{2}$/', $incDate)) {
+                $foundedDate = $incDate;
+            }
+        }
+
+        $city = $data['regaddress.posttown'] ?? null;
+        $county = $data['regaddress.county'] ?? null;
+
+        $this->upsertCompany([
+            'name' => trim($name),
+            'founded_date' => $foundedDate,
+            'city' => $city,
+            'state' => $county,
+            'country' => 'GB',
+            'status' => $status,
+            'category' => $category,
+        ]);
+    }
+
+    private function extractSicCodes(array $data): array
+    {
+        $codes = [];
+        for ($i = 1; $i <= 4; $i++) {
+            $key = "siccode.sictext_{$i}";
+            $value = $data[$key] ?? '';
+            if ($value && trim($value)) {
+                // Extract numeric SIC code from "62012 - Business and domestic software development"
+                if (preg_match('/^(\d+)/', trim($value), $m)) {
+                    $codes[] = $m[1];
+                }
+            }
+        }
+        return $codes;
+    }
+
+    private function categorizeBySic(array $sicCodes): ?string
+    {
+        foreach ($sicCodes as $code) {
+            $prefix = substr($code, 0, 2);
+            if (isset(self::TECH_SIC_PREFIXES[$prefix])) {
+                return self::TECH_SIC_PREFIXES[$prefix];
+            }
+        }
+        return null;
+    }
+
+    private function mapCompaniesHouseStatus(string $status): string
+    {
+        $status = strtolower(trim($status));
+
+        $map = [
+            'active' => 'operating',
+            'active - proposal to strike off' => 'operating',
+            'dissolved' => 'closed',
+            'liquidation' => 'closed',
+            'administration' => 'closed',
+            'voluntary arrangement' => 'closed',
+            'converted/closed' => 'closed',
+            'insolvency proceedings' => 'closed',
+            'receivership' => 'closed',
+            'live' => 'operating',
+        ];
+
+        return $map[$status] ?? 'operating';
+    }
+
+    private function downloadCsv(): string
+    {
+        // Try current month, then previous month
+        $dates = [
+            now()->format('Y-m-01'),
+            now()->subMonth()->format('Y-m-01'),
+        ];
+
+        $storageDir = storage_path('app/imports/companies-house');
+        if (!is_dir($storageDir)) {
+            mkdir($storageDir, 0755, true);
+        }
+
+        foreach ($dates as $date) {
+            $url = sprintf(self::DOWNLOAD_URL, $date);
+            $zipPath = "{$storageDir}/BasicCompanyData-{$date}.zip";
+            $csvPath = "{$storageDir}/BasicCompanyData-{$date}.csv";
+
+            // If CSV already extracted, use it
+            if (file_exists($csvPath)) {
+                Log::info("Using existing Companies House CSV: {$csvPath}");
+                return $csvPath;
+            }
+
+            // Check for any existing CSV
+            $existingCsvs = glob("{$storageDir}/*.csv");
+            if (!empty($existingCsvs)) {
+                $latest = end($existingCsvs);
+                Log::info("Using existing Companies House CSV: {$latest}");
+                return $latest;
+            }
+
+            Log::info("Downloading Companies House data from: {$url}");
+            Log::info("This is ~500MB and will take a while...");
+
+            // Download with curl for progress and resume support
+            $exitCode = 0;
+            $output = [];
+            exec("curl -L -f -o " . escapeshellarg($zipPath) . " " . escapeshellarg($url) . " 2>&1", $output, $exitCode);
+
+            if ($exitCode !== 0) {
+                Log::warning("Failed to download from {$url}");
+                continue;
+            }
+
+            // Extract ZIP
+            $zip = new \ZipArchive();
+            if ($zip->open($zipPath) === true) {
+                $zip->extractTo($storageDir);
+                $zip->close();
+                unlink($zipPath);
+
+                // Find the extracted CSV
+                $csvFiles = glob("{$storageDir}/*.csv");
+                if (!empty($csvFiles)) {
+                    return $csvFiles[0];
+                }
+            }
+        }
+
+        throw new \RuntimeException(
+            "Could not download Companies House data. " .
+            "Please download manually from https://download.companieshouse.gov.uk/en_output.html " .
+            "and pass --file=/path/to/csv"
+        );
+    }
+}

--- a/app/Services/BulkImport/OpenCorporatesBulkImporter.php
+++ b/app/Services/BulkImport/OpenCorporatesBulkImporter.php
@@ -1,0 +1,198 @@
+<?php
+
+namespace App\Services\BulkImport;
+
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+
+class OpenCorporatesBulkImporter extends BaseBulkImporter
+{
+    private const BASE_URL = 'https://api.opencorporates.com/v0.4';
+
+    private const KEYWORDS = [
+        'technology',
+        'software',
+        'artificial intelligence',
+        'machine learning',
+        'saas',
+        'cloud computing',
+        'fintech',
+        'biotech',
+        'startup',
+    ];
+
+    private const JURISDICTIONS = ['us_de', 'us_ca', 'us_ny', 'us_wa'];
+
+    // Free tier: 500 requests/day with API key, 50 without
+    private const RATE_LIMIT_SECONDS = 8.0; // ~450 requests/hour, well within limits
+    private const PER_PAGE = 30;
+
+    public function source(): string
+    {
+        return 'opencorporates';
+    }
+
+    public function import(array $options = []): void
+    {
+        $apiToken = config('services.opencorporates.api_token', env('OPENCORPORATES_API_TOKEN'));
+        $maxPages = $options['max_pages'] ?? 5; // Conservative default for free tier
+        $createdSince = $options['created_since'] ?? '2020-01-01';
+
+        Log::info("OpenCorporates import starting", [
+            'has_token' => !empty($apiToken),
+            'max_pages' => $maxPages,
+            'created_since' => $createdSince,
+        ]);
+
+        if (empty($apiToken)) {
+            Log::warning("OpenCorporates: No API token configured. Set OPENCORPORATES_API_TOKEN in .env");
+            Log::warning("OpenCorporates: Get a free API key at https://opencorporates.com/users/sign_up");
+            return;
+        }
+
+        foreach (self::JURISDICTIONS as $jurisdiction) {
+            foreach (self::KEYWORDS as $keyword) {
+                $this->searchAndImport($keyword, $jurisdiction, $createdSince, $apiToken, $maxPages);
+            }
+        }
+
+        Log::info("OpenCorporates import complete", $this->getStats());
+    }
+
+    private function searchAndImport(
+        string $query,
+        string $jurisdiction,
+        string $createdSince,
+        ?string $apiToken,
+        int $maxPages
+    ): void {
+        for ($page = 1; $page <= $maxPages; $page++) {
+            $params = [
+                'q' => $query,
+                'jurisdiction_code' => $jurisdiction,
+                'created_since' => $createdSince,
+                'per_page' => self::PER_PAGE,
+                'page' => $page,
+                'order' => 'incorporation_date',
+            ];
+
+            if ($apiToken) {
+                $params['api_token'] = $apiToken;
+            }
+
+            try {
+                $response = Http::timeout(30)->get(self::BASE_URL . '/companies/search', $params);
+
+                if ($response->status() === 401 || $response->status() === 403) {
+                    Log::warning("OpenCorporates: API token required or invalid. Stopping.");
+                    return;
+                }
+
+                if ($response->status() === 429) {
+                    Log::warning("OpenCorporates: Rate limit hit. Stopping search for {$query}/{$jurisdiction}.");
+                    return;
+                }
+
+                if (!$response->successful()) {
+                    Log::warning("OpenCorporates: HTTP {$response->status()} for {$query}/{$jurisdiction} page {$page}");
+                    break;
+                }
+
+                $data = $response->json();
+                $companies = $data['results']['companies'] ?? [];
+
+                if (empty($companies)) {
+                    break;
+                }
+
+                foreach ($companies as $item) {
+                    $company = $item['company'] ?? $item;
+                    $this->importCompany($company, $jurisdiction);
+                }
+
+                $totalPages = $data['results']['total_pages'] ?? $page;
+                if ($page >= $totalPages) {
+                    break;
+                }
+
+                // Update checkpoint
+                $this->importLog->update([
+                    'last_offset' => "{$jurisdiction}:{$query}:{$page}",
+                    'total_processed' => $this->processed,
+                    'companies_created' => $this->created,
+                ]);
+
+                $this->rateLimitSleep(self::RATE_LIMIT_SECONDS);
+
+            } catch (\Exception $e) {
+                Log::error("OpenCorporates: Error fetching {$query}/{$jurisdiction} page {$page}: {$e->getMessage()}");
+                break;
+            }
+        }
+    }
+
+    private function importCompany(array $company, string $jurisdiction): void
+    {
+        $name = $company['name'] ?? null;
+        if (!$name) return;
+
+        // Clean up ALL CAPS names common in corporate registries
+        if ($name === strtoupper($name) && strlen($name) > 3) {
+            $name = ucwords(strtolower($name));
+        }
+
+        // Remove common suffixes for cleaner names but keep original for matching
+        $status = $this->mapOpenCorpStatus($company['current_status'] ?? '');
+
+        $state = $this->jurisdictionToState($jurisdiction);
+        $country = str_starts_with($jurisdiction, 'us_') ? 'US' : null;
+
+        $foundedDate = $company['incorporation_date'] ?? null;
+
+        $address = $company['registered_address'] ?? [];
+        $city = $address['locality'] ?? null;
+
+        $this->upsertCompany([
+            'name' => trim($name),
+            'founded_date' => $foundedDate,
+            'city' => $city,
+            'state' => $state,
+            'country' => $country,
+            'status' => $status,
+        ]);
+    }
+
+    private function mapOpenCorpStatus(string $status): string
+    {
+        $status = strtolower(trim($status));
+
+        $map = [
+            'active' => 'operating',
+            'good standing' => 'operating',
+            'in good standing' => 'operating',
+            'current' => 'operating',
+            'dissolved' => 'closed',
+            'inactive' => 'closed',
+            'revoked' => 'closed',
+            'forfeited' => 'closed',
+            'cancelled' => 'closed',
+            'withdrawn' => 'closed',
+            'merged' => 'acquired',
+            'converted' => 'acquired',
+        ];
+
+        return $map[$status] ?? 'operating';
+    }
+
+    private function jurisdictionToState(string $jurisdiction): ?string
+    {
+        $map = [
+            'us_de' => 'DE',
+            'us_ca' => 'CA',
+            'us_ny' => 'NY',
+            'us_wa' => 'WA',
+        ];
+
+        return $map[$jurisdiction] ?? null;
+    }
+}

--- a/app/Services/BulkImport/WikipediaUnicornImporter.php
+++ b/app/Services/BulkImport/WikipediaUnicornImporter.php
@@ -1,0 +1,213 @@
+<?php
+
+namespace App\Services\BulkImport;
+
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+
+class WikipediaUnicornImporter extends BaseBulkImporter
+{
+    private const WIKIPEDIA_API = 'https://en.wikipedia.org/w/api.php';
+
+    private const PAGES = [
+        'List_of_unicorn_startup_companies',
+    ];
+
+    public function source(): string
+    {
+        return 'wikipedia';
+    }
+
+    public function import(array $options = []): void
+    {
+        Log::info("Wikipedia unicorn import starting");
+
+        foreach (self::PAGES as $page) {
+            $this->importFromPage($page);
+        }
+
+        Log::info("Wikipedia unicorn import complete", $this->getStats());
+    }
+
+    private function importFromPage(string $pageTitle): void
+    {
+        // Use Wikipedia API to get page content in parsed HTML
+        $response = Http::timeout(30)->withUserAgent('StartupGraph/1.0 (https://startupgraph.com)')->get(self::WIKIPEDIA_API, [
+            'action' => 'parse',
+            'page' => $pageTitle,
+            'format' => 'json',
+            'prop' => 'wikitext',
+        ]);
+
+        if (!$response->successful()) {
+            Log::warning("Wikipedia: Failed to fetch {$pageTitle}");
+            return;
+        }
+
+        $data = $response->json();
+        $wikitext = $data['parse']['wikitext']['*'] ?? '';
+
+        if (empty($wikitext)) {
+            Log::warning("Wikipedia: Empty wikitext for {$pageTitle}");
+            return;
+        }
+
+        // Parse wikitable rows - unicorn tables typically have: Company, Valuation, Date, Country, Industry
+        $this->parseWikiTables($wikitext);
+    }
+
+    private function parseWikiTables(string $wikitext): void
+    {
+        // Split by row separators |-
+        $rows = preg_split('/\n\|-/', $wikitext);
+
+        // Find the header row containing !Company and !Industry
+        $headerIdx = null;
+        $columns = [];
+        foreach ($rows as $i => $row) {
+            // Headers use ! prefix on each line
+            if (str_contains($row, '!Company') && str_contains($row, '!Industry')) {
+                // Parse header cells: each starts with ! on its own line
+                preg_match_all('/\n!\s*(.+)/', "\n" . $row, $headerMatches);
+                $columns = array_map(fn($h) => strtolower($this->cleanWikiText($h)), $headerMatches[1] ?? []);
+                $headerIdx = $i;
+                Log::info("Wikipedia: Found header at row {$i} with columns: " . implode(', ', $columns));
+                break;
+            }
+        }
+
+        if ($headerIdx === null || empty($columns)) {
+            Log::warning("Wikipedia: Could not find company table headers");
+            return;
+        }
+
+        // Column indices (0-based)
+        $nameCol = $this->findColumn($columns, ['company', 'name']);
+        $countryCol = $this->findColumn($columns, ['country']);
+        $industryCol = $this->findColumn($columns, ['industry', 'sector']);
+
+        if ($nameCol === null) {
+            Log::warning("Wikipedia: No company column found in: " . implode(', ', $columns));
+            return;
+        }
+
+        // Process data rows after header
+        for ($i = $headerIdx + 1; $i < count($rows); $i++) {
+            $row = $rows[$i];
+
+            // Stop if we hit end of table or new section
+            if (str_contains($row, '|}')) break;
+
+            // Each data cell starts with | on its own line
+            // Split by \n| but not \n|- or \n|} or \n||
+            $cells = [];
+            $lines = explode("\n", $row);
+            foreach ($lines as $line) {
+                $line = trim($line);
+                if ($line === '' || $line === '|-' || $line === '|}') continue;
+                if (str_starts_with($line, '|')) {
+                    $cells[] = substr($line, 1);
+                }
+            }
+
+            if (count($cells) < 3) continue;
+
+            $name = $this->cleanWikiText($cells[$nameCol] ?? '');
+            if (!$name || strlen($name) < 2 || is_numeric($name)) continue;
+
+            // Skip non-company entries
+            if (str_contains(strtolower($name), 'total') || str_contains($name, '=')) continue;
+
+            $country = $countryCol !== null ? $this->cleanWikiText($cells[$countryCol] ?? '') : null;
+            // Clean flag template from country: {{flag|United States}} -> United States
+            if ($country) {
+                $country = preg_replace('/flag\|/i', '', $country);
+            }
+
+            $industry = $industryCol !== null ? $this->cleanWikiText($cells[$industryCol] ?? '') : null;
+
+            $countryCode = $this->mapCountryName($country);
+            $category = $this->mapIndustry($industry);
+
+            $this->upsertCompany([
+                'name' => trim($name),
+                'country' => $countryCode,
+                'category' => $category,
+                'status' => 'operating',
+            ]);
+        }
+    }
+
+    private function findColumn(array $headers, array $keywords): ?int
+    {
+        foreach ($headers as $i => $header) {
+            foreach ($keywords as $kw) {
+                if (str_contains($header, $kw)) {
+                    return $i;
+                }
+            }
+        }
+        return null;
+    }
+
+    private function cleanWikiText(string $text): string
+    {
+        // Remove wiki links: [[Target|Display]] -> Display, [[Target]] -> Target
+        $text = preg_replace('/\[\[(?:[^|\]]*\|)?([^\]]+)\]\]/', '$1', $text);
+        // Remove templates {{ }}
+        $text = preg_replace('/\{\{[^}]*\}\}/', '', $text);
+        // Remove HTML tags
+        $text = strip_tags($text);
+        // Remove refs
+        $text = preg_replace('/<ref[^>]*>.*?<\/ref>/s', '', $text);
+        $text = preg_replace('/<ref[^>]*\/?>/s', '', $text);
+        // Clean whitespace
+        $text = trim(preg_replace('/\s+/', ' ', $text));
+
+        return $text;
+    }
+
+    private function mapCountryName(?string $country): ?string
+    {
+        if (!$country) return null;
+        $country = strtolower(trim($country));
+
+        $map = [
+            'united states' => 'US', 'usa' => 'US', 'u.s.' => 'US', 'us' => 'US',
+            'united kingdom' => 'GB', 'uk' => 'GB',
+            'china' => 'CN', 'india' => 'IN', 'germany' => 'DE', 'france' => 'FR',
+            'canada' => 'CA', 'israel' => 'IL', 'brazil' => 'BR', 'australia' => 'AU',
+            'japan' => 'JP', 'south korea' => 'KR', 'singapore' => 'SG',
+            'sweden' => 'SE', 'netherlands' => 'NL', 'indonesia' => 'ID',
+            'ireland' => 'IE', 'switzerland' => 'CH', 'hong kong' => 'HK',
+        ];
+
+        return $map[$country] ?? strtoupper(substr($country, 0, 2));
+    }
+
+    private function mapIndustry(?string $industry): ?string
+    {
+        if (!$industry) return null;
+        $industry = strtolower($industry);
+
+        $map = [
+            'artificial intelligence' => 'ai_ml',
+            'fintech' => 'fintech', 'financial' => 'fintech',
+            'health' => 'healthcare', 'biotech' => 'healthcare',
+            'e-commerce' => 'consumer', 'consumer' => 'consumer',
+            'enterprise' => 'enterprise', 'saas' => 'enterprise', 'software' => 'enterprise',
+            'cybersecurity' => 'enterprise', 'cyber security' => 'enterprise',
+            'robotics' => 'robotics', 'hardware' => 'robotics',
+            'clean' => 'climate', 'energy' => 'climate',
+            'defense' => 'defense', 'aerospace' => 'defense',
+        ];
+
+        foreach ($map as $keyword => $category) {
+            if (str_contains($industry, $keyword)) {
+                return $category;
+            }
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
## New Data Sources

### 1. OpenCorporates API (`--source=opencorporates`)
- Searches by tech keywords (technology, software, AI, SaaS, etc.)
- Filters to US jurisdictions: DE, CA, NY, WA
- Rate-limited for free tier (8s between requests)
- **Requires API token**: set `OPENCORPORATES_API_TOKEN` in .env
- Get free key at https://opencorporates.com/users/sign_up

### 2. Companies House UK CSV (`--source=companies-house`)
- Downloads ~500MB bulk CSV from Companies House (all UK companies)
- Filters by SIC codes to find tech/startup companies
- Filters by incorporation year (default: 2015+)
- Options: `--file=`, `--min-year=`, `--tech-only`

### 3. Wikipedia Unicorns (`--source=wikipedia`)
- Parses Wikipedia's "List of unicorn startup companies"
- Extracts company name, country, industry from wiki tables
- **First run results**: 638 created, 61 updated, 720 total processed

### Total company count: 6,502