### PR TITLE
Feature: Wikipedia (acquisitions + defunct + categories) and GitHub org importers

### DIFF
--- a/app/Console/Commands/BulkImportCompanies.php
+++ b/app/Console/Commands/BulkImportCompanies.php
@@ -5,9 +5,13 @@ namespace App\Console\Commands;
 use App\Services\BulkImport\CompaniesHouseCsvImporter;
 use App\Services\BulkImport\CrunchbaseCsvImporter;
 use App\Services\BulkImport\EdgarBulkImporter;
+use App\Services\BulkImport\GitHubOrgImporter;
 use App\Services\BulkImport\GitHubTrendingImporter;
 use App\Services\BulkImport\OpenCorporatesBulkImporter;
 use App\Services\BulkImport\ProductHuntBulkImporter;
+use App\Services\BulkImport\WikipediaAcquisitionsImporter;
+use App\Services\BulkImport\WikipediaCategoryImporter;
+use App\Services\BulkImport\WikipediaDefunctImporter;
 use App\Services\BulkImport\WikipediaUnicornImporter;
 use App\Services\BulkImport\YCBulkImporter;
 use Illuminate\Console\Command;
@@ -15,7 +19,7 @@ use Illuminate\Console\Command;
 class BulkImportCompanies extends Command
 {
     protected $signature = 'companies:bulk-import
-        {--source= : Import source (yc, crunchbase, producthunt, edgar, github, opencorporates, companies-house, wikipedia)}
+        {--source= : Import source (yc, crunchbase, producthunt, edgar, github, opencorporates, companies-house, wikipedia, wikipedia-acquisitions, wikipedia-defunct, wikipedia-categories, github-orgs)}
         {--file= : CSV file path (required for crunchbase, optional for companies-house)}
         {--all : Run all sources}
         {--resume : Resume from last checkpoint}
@@ -34,6 +38,10 @@ class BulkImportCompanies extends Command
         'opencorporates' => OpenCorporatesBulkImporter::class,
         'companies-house' => CompaniesHouseCsvImporter::class,
         'wikipedia' => WikipediaUnicornImporter::class,
+        'wikipedia-acquisitions' => WikipediaAcquisitionsImporter::class,
+        'wikipedia-defunct' => WikipediaDefunctImporter::class,
+        'wikipedia-categories' => WikipediaCategoryImporter::class,
+        'github-orgs' => GitHubOrgImporter::class,
     ];
 
     public function handle(): int

--- a/app/Services/BulkImport/GitHubOrgImporter.php
+++ b/app/Services/BulkImport/GitHubOrgImporter.php
@@ -1,0 +1,213 @@
+<?php
+
+namespace App\Services\BulkImport;
+
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+
+class GitHubOrgImporter extends BaseBulkImporter
+{
+    private const GITHUB_API = 'https://api.github.com';
+
+    private const SEARCH_QUERIES = [
+        'type:org location:"san francisco" repos:>5',
+        'type:org location:"new york" repos:>5',
+        'type:org location:"london" repos:>5',
+        'type:org location:"berlin" repos:>5',
+        'type:org location:"seattle" repos:>5',
+        'type:org location:"austin" repos:>5',
+        'type:org location:"denver" repos:>5',
+        'type:org location:"los angeles" repos:>5',
+        'type:org location:"boston" repos:>5',
+        'type:org location:"toronto" repos:>5',
+        'type:org created:>2020-01-01 repos:>10',
+    ];
+
+    private ?string $token;
+    private int $requestCount = 0;
+    private float $windowStart;
+
+    public function source(): string
+    {
+        return 'github-orgs';
+    }
+
+    public function import(array $options = []): void
+    {
+        $this->token = env('GITHUB_TOKEN') ?: null;
+        $this->windowStart = microtime(true);
+
+        Log::info("GitHub org import starting", ['has_token' => (bool) $this->token]);
+
+        foreach (self::SEARCH_QUERIES as $query) {
+            Log::info("Searching GitHub orgs: {$query}");
+            $this->searchAndImport($query, $options['max_pages'] ?? 10);
+        }
+
+        Log::info("GitHub org import complete", $this->getStats());
+    }
+
+    private function searchAndImport(string $query, int $maxPages): void
+    {
+        // GitHub search API returns max 1000 results (10 pages of 100)
+        $maxPages = min($maxPages, 10);
+
+        for ($page = 1; $page <= $maxPages; $page++) {
+            $this->enforceRateLimit();
+
+            $response = $this->githubGet('/search/users', [
+                'q' => $query,
+                'per_page' => 100,
+                'page' => $page,
+            ]);
+
+            if (!$response || !$response->successful()) {
+                if ($response && $response->status() === 403) {
+                    Log::warning("GitHub: Rate limited, waiting 60s");
+                    sleep(60);
+                    $page--; // Retry
+                    continue;
+                }
+                Log::warning("GitHub: Search failed for query: {$query}");
+                break;
+            }
+
+            $data = $response->json();
+            $items = $data['items'] ?? [];
+
+            if (empty($items)) break;
+
+            foreach ($items as $item) {
+                $login = $item['login'] ?? '';
+                if (!$login) continue;
+
+                $this->importOrg($login);
+            }
+
+            // Check if there are more results
+            $totalCount = $data['total_count'] ?? 0;
+            if ($page * 100 >= $totalCount) break;
+        }
+    }
+
+    private function importOrg(string $login): void
+    {
+        $this->enforceRateLimit();
+
+        $response = $this->githubGet("/orgs/{$login}");
+
+        if (!$response || !$response->successful()) return;
+
+        $org = $response->json();
+
+        $name = $org['name'] ?? $org['login'] ?? '';
+        $blog = $org['blog'] ?? '';
+        $description = $org['description'] ?? '';
+        $location = $org['location'] ?? '';
+        $email = $org['email'] ?? '';
+        $twitter = $org['twitter_username'] ?? '';
+        $createdAt = $org['created_at'] ?? '';
+
+        // Skip orgs without a name or website (less likely to be companies)
+        if (!$name || strlen($name) < 2) {
+            $this->skipped++;
+            $this->processed++;
+            return;
+        }
+
+        // Parse location into city/country
+        $locationParts = $this->parseLocation($location);
+
+        // Parse website
+        $website = $blog;
+        if ($website && !str_starts_with($website, 'http')) {
+            $website = 'https://' . $website;
+        }
+
+        // Parse founded date from created_at
+        $foundedDate = null;
+        if ($createdAt && preg_match('/^(\d{4}-\d{2}-\d{2})/', $createdAt, $m)) {
+            $foundedDate = $m[1];
+        }
+
+        $this->upsertCompany([
+            'name' => $name,
+            'website' => $website ?: null,
+            'description' => $description ? substr($description, 0, 500) : null,
+            'city' => $locationParts['city'] ?? null,
+            'country' => $locationParts['country'] ?? null,
+            'status' => 'operating',
+            'founded_date' => $foundedDate,
+        ]);
+    }
+
+    private function githubGet(string $path, array $query = []): ?\Illuminate\Http\Client\Response
+    {
+        $this->requestCount++;
+
+        $request = Http::timeout(30)
+            ->withUserAgent('StartupGraph/1.0')
+            ->accept('application/vnd.github.v3+json');
+
+        if ($this->token) {
+            $request = $request->withToken($this->token);
+        }
+
+        try {
+            return $request->get(self::GITHUB_API . $path, $query);
+        } catch (\Exception $e) {
+            Log::warning("GitHub API error: {$e->getMessage()}");
+            return null;
+        }
+    }
+
+    private function enforceRateLimit(): void
+    {
+        // 30 requests per minute
+        $elapsed = microtime(true) - $this->windowStart;
+
+        if ($this->requestCount >= 28 && $elapsed < 60) {
+            $wait = 60 - $elapsed + 1;
+            Log::info("GitHub: Rate limit pause for {$wait}s");
+            sleep((int) ceil($wait));
+            $this->requestCount = 0;
+            $this->windowStart = microtime(true);
+        }
+
+        if ($elapsed >= 60) {
+            $this->requestCount = 0;
+            $this->windowStart = microtime(true);
+        }
+    }
+
+    private function parseLocation(?string $location): array
+    {
+        if (!$location) return [];
+
+        $cityCountryMap = [
+            'san francisco' => ['city' => 'San Francisco', 'country' => 'US'],
+            'new york' => ['city' => 'New York', 'country' => 'US'],
+            'london' => ['city' => 'London', 'country' => 'GB'],
+            'berlin' => ['city' => 'Berlin', 'country' => 'DE'],
+            'seattle' => ['city' => 'Seattle', 'country' => 'US'],
+            'austin' => ['city' => 'Austin', 'country' => 'US'],
+            'denver' => ['city' => 'Denver', 'country' => 'US'],
+            'los angeles' => ['city' => 'Los Angeles', 'country' => 'US'],
+            'boston' => ['city' => 'Boston', 'country' => 'US'],
+            'toronto' => ['city' => 'Toronto', 'country' => 'CA'],
+        ];
+
+        $lower = strtolower($location);
+        foreach ($cityCountryMap as $key => $val) {
+            if (str_contains($lower, $key)) return $val;
+        }
+
+        // Try to parse "City, Country" or "City, State, Country"
+        $parts = array_map('trim', explode(',', $location));
+        if (count($parts) >= 2) {
+            return ['city' => $parts[0]];
+        }
+
+        return ['city' => $location];
+    }
+}

--- a/app/Services/BulkImport/WikipediaAcquisitionsImporter.php
+++ b/app/Services/BulkImport/WikipediaAcquisitionsImporter.php
@@ -1,0 +1,184 @@
+<?php
+
+namespace App\Services\BulkImport;
+
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+
+class WikipediaAcquisitionsImporter extends BaseBulkImporter
+{
+    private const WIKIPEDIA_API = 'https://en.wikipedia.org/w/api.php';
+
+    private const ACQUIRER_PAGES = [
+        'Alphabet' => 'List_of_mergers_and_acquisitions_by_Alphabet',
+        'Apple' => 'List_of_mergers_and_acquisitions_by_Apple',
+        'Meta Platforms' => 'List_of_mergers_and_acquisitions_by_Meta_Platforms',
+        'Microsoft' => 'List_of_mergers_and_acquisitions_by_Microsoft',
+        'Amazon' => 'List_of_mergers_and_acquisitions_by_Amazon',
+        'Salesforce' => 'List_of_mergers_and_acquisitions_by_Salesforce',
+        'Oracle' => 'List_of_mergers_and_acquisitions_by_Oracle',
+        'Cisco Systems' => 'List_of_mergers_and_acquisitions_by_Cisco_Systems',
+        'IBM' => 'List_of_mergers_and_acquisitions_by_IBM',
+        'Intel' => 'List_of_mergers_and_acquisitions_by_Intel',
+        'Yahoo!' => 'List_of_mergers_and_acquisitions_by_Yahoo!',
+        'Twitter' => 'List_of_mergers_and_acquisitions_by_Twitter',
+    ];
+
+    public function source(): string
+    {
+        return 'wikipedia-acquisitions';
+    }
+
+    public function import(array $options = []): void
+    {
+        Log::info("Wikipedia acquisitions import starting");
+
+        foreach (self::ACQUIRER_PAGES as $acquirer => $page) {
+            Log::info("Importing acquisitions by {$acquirer}");
+            $this->importFromPage($acquirer, $page);
+            $this->rateLimitSleep(1.0);
+        }
+
+        Log::info("Wikipedia acquisitions import complete", $this->getStats());
+    }
+
+    private function importFromPage(string $acquirer, string $pageTitle): void
+    {
+        $response = Http::timeout(30)
+            ->withUserAgent('StartupGraph/1.0 (https://startupgraph.com)')
+            ->get(self::WIKIPEDIA_API, [
+                'action' => 'parse',
+                'page' => $pageTitle,
+                'format' => 'json',
+                'prop' => 'wikitext',
+            ]);
+
+        if (!$response->successful()) {
+            Log::warning("Wikipedia: Failed to fetch {$pageTitle}");
+            return;
+        }
+
+        $data = $response->json();
+        $wikitext = $data['parse']['wikitext']['*'] ?? '';
+
+        if (empty($wikitext)) {
+            Log::warning("Wikipedia: Empty wikitext for {$pageTitle}");
+            return;
+        }
+
+        $this->parseAcquisitionTables($wikitext, $acquirer);
+    }
+
+    private function parseAcquisitionTables(string $wikitext, string $acquirer): void
+    {
+        // Split into table sections
+        $rows = preg_split('/\n\|-/', $wikitext);
+
+        $columns = [];
+        $headerFound = false;
+
+        foreach ($rows as $i => $row) {
+            // Look for header rows with ! markers
+            if (!$headerFound && preg_match_all('/\n!\s*(.+)/', "\n" . $row, $headerMatches)) {
+                $headers = $headerMatches[1] ?? [];
+                if (count($headers) >= 2) {
+                    $columns = array_map(fn($h) => strtolower($this->cleanWikiText($h)), $headers);
+                    // Check if this looks like an acquisitions table
+                    $hasCompany = $this->findColumn($columns, ['company', 'acquisition', 'name', 'target']);
+                    if ($hasCompany !== null) {
+                        $headerFound = true;
+                        continue;
+                    }
+                }
+            }
+
+            if (!$headerFound) continue;
+
+            // End of table
+            if (str_contains($row, '|}')) {
+                $headerFound = false;
+                continue;
+            }
+
+            // Parse cells
+            $cells = $this->extractCells($row);
+            if (count($cells) < 2) continue;
+
+            $nameCol = $this->findColumn($columns, ['company', 'acquisition', 'name', 'target']);
+            $dateCol = $this->findColumn($columns, ['date', 'announced', 'completed', 'year']);
+            $priceCol = $this->findColumn($columns, ['price', 'value', 'amount', 'cost']);
+            $descCol = $this->findColumn($columns, ['description', 'business', 'area', 'notes', 'used for', 'products/services']);
+
+            $name = $this->cleanWikiText($cells[$nameCol] ?? '');
+            if (!$name || strlen($name) < 2 || is_numeric($name)) continue;
+            if (str_contains(strtolower($name), 'total') || str_contains($name, '=')) continue;
+
+            $date = $dateCol !== null ? $this->cleanWikiText($cells[$dateCol] ?? '') : null;
+            $description = $descCol !== null ? $this->cleanWikiText($cells[$descCol] ?? '') : null;
+            $price = $priceCol !== null ? $this->cleanWikiText($cells[$priceCol] ?? '') : null;
+
+            // Build description with price info
+            $fullDesc = $description;
+            if ($price && $price !== '' && strtolower($price) !== 'n/a' && strtolower($price) !== 'undisclosed') {
+                $fullDesc = ($fullDesc ? $fullDesc . '. ' : '') . "Acquired for {$price}.";
+            }
+
+            // Parse founded/acquisition date
+            $foundedDate = null;
+            if ($date) {
+                // Try to extract a year
+                if (preg_match('/(\d{4})/', $date, $m)) {
+                    $foundedDate = $m[1] . '-01-01';
+                }
+            }
+
+            $this->upsertCompany([
+                'name' => $name,
+                'status' => 'acquired',
+                'acquired_by' => $acquirer,
+                'description' => $fullDesc ? substr($fullDesc, 0, 500) : null,
+            ]);
+        }
+    }
+
+    private function extractCells(string $row): array
+    {
+        $cells = [];
+        $lines = explode("\n", $row);
+        foreach ($lines as $line) {
+            $line = trim($line);
+            if ($line === '' || $line === '|-' || $line === '|}') continue;
+            if (str_starts_with($line, '|')) {
+                // Handle multiple cells on one line separated by ||
+                $parts = explode('||', substr($line, 1));
+                foreach ($parts as $part) {
+                    $cells[] = trim($part);
+                }
+            }
+        }
+        return $cells;
+    }
+
+    private function findColumn(array $headers, array $keywords): ?int
+    {
+        foreach ($headers as $i => $header) {
+            foreach ($keywords as $kw) {
+                if (str_contains($header, $kw)) {
+                    return $i;
+                }
+            }
+        }
+        return null;
+    }
+
+    private function cleanWikiText(string $text): string
+    {
+        $text = preg_replace('/\[\[(?:[^|\]]*\|)?([^\]]+)\]\]/', '$1', $text);
+        $text = preg_replace('/\{\{[^}]*\}\}/', '', $text);
+        $text = strip_tags($text);
+        $text = preg_replace('/<ref[^>]*>.*?<\/ref>/s', '', $text);
+        $text = preg_replace('/<ref[^>]*\/?>/s', '', $text);
+        $text = trim(preg_replace('/\s+/', ' ', $text));
+        return $text;
+    }
+}

--- a/app/Services/BulkImport/WikipediaCategoryImporter.php
+++ b/app/Services/BulkImport/WikipediaCategoryImporter.php
@@ -1,0 +1,148 @@
+<?php
+
+namespace App\Services\BulkImport;
+
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+
+class WikipediaCategoryImporter extends BaseBulkImporter
+{
+    private const WIKIPEDIA_API = 'https://en.wikipedia.org/w/api.php';
+
+    private const CATEGORIES = [
+        // Technology companies by year
+        'Category:Technology_companies_established_in_2020' => 'operating',
+        'Category:Technology_companies_established_in_2021' => 'operating',
+        'Category:Technology_companies_established_in_2022' => 'operating',
+        'Category:Technology_companies_established_in_2023' => 'operating',
+        'Category:Technology_companies_established_in_2024' => 'operating',
+        'Category:Technology_companies_established_in_2025' => 'operating',
+        // American companies by year
+        'Category:American_companies_established_in_2020' => 'operating',
+        'Category:American_companies_established_in_2021' => 'operating',
+        'Category:American_companies_established_in_2022' => 'operating',
+        'Category:American_companies_established_in_2023' => 'operating',
+        'Category:American_companies_established_in_2024' => 'operating',
+        'Category:American_companies_established_in_2025' => 'operating',
+    ];
+
+    public function source(): string
+    {
+        return 'wikipedia-categories';
+    }
+
+    public function import(array $options = []): void
+    {
+        Log::info("Wikipedia category companies import starting");
+
+        foreach (self::CATEGORIES as $category => $status) {
+            Log::info("Importing from {$category}");
+            $this->importCategory($category, $status);
+        }
+
+        Log::info("Wikipedia category companies import complete", $this->getStats());
+    }
+
+    private function importCategory(string $category, string $status): void
+    {
+        $continue = null;
+
+        // Extract year from category name for founded_date
+        $year = null;
+        if (preg_match('/(\d{4})/', $category, $m)) {
+            $year = $m[1];
+        }
+
+        // Determine country from category
+        $country = str_contains($category, 'American') ? 'US' : null;
+
+        do {
+            $params = [
+                'action' => 'query',
+                'list' => 'categorymembers',
+                'cmtitle' => $category,
+                'cmlimit' => 500,
+                'cmtype' => 'page',
+                'cmnamespace' => 0,
+                'format' => 'json',
+            ];
+
+            if ($continue) {
+                $params['cmcontinue'] = $continue;
+            }
+
+            $response = Http::timeout(30)
+                ->withUserAgent('StartupGraph/1.0 (https://startupgraph.com)')
+                ->get(self::WIKIPEDIA_API, $params);
+
+            if (!$response->successful()) {
+                Log::warning("Wikipedia: Failed to fetch category {$category}");
+                break;
+            }
+
+            $data = $response->json();
+            $members = $data['query']['categorymembers'] ?? [];
+            $continue = $data['continue']['cmcontinue'] ?? null;
+
+            // Batch fetch extracts
+            $titles = array_map(fn($m) => $m['title'], $members);
+            $chunks = array_chunk($titles, 50);
+
+            foreach ($chunks as $chunk) {
+                $this->fetchAndImportExtracts($chunk, $status, $year, $country);
+                $this->rateLimitSleep(1.0);
+            }
+
+        } while ($continue);
+    }
+
+    private function fetchAndImportExtracts(array $titles, string $status, ?string $year, ?string $country): void
+    {
+        $response = Http::timeout(30)
+            ->withUserAgent('StartupGraph/1.0 (https://startupgraph.com)')
+            ->get(self::WIKIPEDIA_API, [
+                'action' => 'query',
+                'titles' => implode('|', $titles),
+                'prop' => 'extracts',
+                'exintro' => true,
+                'explaintext' => true,
+                'exlimit' => count($titles),
+                'format' => 'json',
+            ]);
+
+        if (!$response->successful()) {
+            foreach ($titles as $title) {
+                $this->upsertCompany([
+                    'name' => $title,
+                    'status' => $status,
+                    'founded_date' => $year ? "{$year}-01-01" : null,
+                    'country' => $country,
+                ]);
+            }
+            return;
+        }
+
+        $pages = $response->json()['query']['pages'] ?? [];
+
+        foreach ($pages as $page) {
+            $title = $page['title'] ?? '';
+            $extract = $page['extract'] ?? '';
+
+            if (!$title || str_starts_with($title, 'Category:')) continue;
+
+            // Skip disambiguation and list pages
+            if (str_contains(strtolower($extract), 'may refer to') ||
+                str_contains(strtolower($title), 'list of')) continue;
+
+            $description = $extract ? substr(trim($extract), 0, 500) : null;
+
+            $this->upsertCompany([
+                'name' => $title,
+                'status' => $status,
+                'description' => $description,
+                'founded_date' => $year ? "{$year}-01-01" : null,
+                'country' => $country,
+            ]);
+        }
+    }
+}

--- a/app/Services/BulkImport/WikipediaDefunctImporter.php
+++ b/app/Services/BulkImport/WikipediaDefunctImporter.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace App\Services\BulkImport;
+
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+
+class WikipediaDefunctImporter extends BaseBulkImporter
+{
+    private const WIKIPEDIA_API = 'https://en.wikipedia.org/w/api.php';
+
+    private const CATEGORIES = [
+        'Category:Defunct_software_companies_of_the_United_States',
+        'Category:Defunct_technology_companies_of_the_United_States',
+    ];
+
+    public function source(): string
+    {
+        return 'wikipedia-defunct';
+    }
+
+    public function import(array $options = []): void
+    {
+        Log::info("Wikipedia defunct companies import starting");
+
+        foreach (self::CATEGORIES as $category) {
+            Log::info("Importing from {$category}");
+            $this->importCategory($category, 'closed');
+        }
+
+        Log::info("Wikipedia defunct companies import complete", $this->getStats());
+    }
+
+    private function importCategory(string $category, string $status): void
+    {
+        $continue = null;
+
+        do {
+            $params = [
+                'action' => 'query',
+                'list' => 'categorymembers',
+                'cmtitle' => $category,
+                'cmlimit' => 500,
+                'cmtype' => 'page',
+                'cmnamespace' => 0, // Main namespace only
+                'format' => 'json',
+            ];
+
+            if ($continue) {
+                $params['cmcontinue'] = $continue;
+            }
+
+            $response = Http::timeout(30)
+                ->withUserAgent('StartupGraph/1.0 (https://startupgraph.com)')
+                ->get(self::WIKIPEDIA_API, $params);
+
+            if (!$response->successful()) {
+                Log::warning("Wikipedia: Failed to fetch category {$category}");
+                break;
+            }
+
+            $data = $response->json();
+            $members = $data['query']['categorymembers'] ?? [];
+            $continue = $data['continue']['cmcontinue'] ?? null;
+
+            // Batch fetch extracts for up to 50 titles at a time
+            $titles = array_map(fn($m) => $m['title'], $members);
+            $chunks = array_chunk($titles, 50);
+
+            foreach ($chunks as $chunk) {
+                $this->fetchAndImportExtracts($chunk, $status);
+                $this->rateLimitSleep(1.0);
+            }
+
+        } while ($continue);
+    }
+
+    private function fetchAndImportExtracts(array $titles, string $status): void
+    {
+        $response = Http::timeout(30)
+            ->withUserAgent('StartupGraph/1.0 (https://startupgraph.com)')
+            ->get(self::WIKIPEDIA_API, [
+                'action' => 'query',
+                'titles' => implode('|', $titles),
+                'prop' => 'extracts',
+                'exintro' => true,
+                'explaintext' => true,
+                'exlimit' => count($titles),
+                'format' => 'json',
+            ]);
+
+        if (!$response->successful()) {
+            // Fall back to just importing names
+            foreach ($titles as $title) {
+                $this->upsertCompany([
+                    'name' => $title,
+                    'status' => $status,
+                    'country' => 'US',
+                ]);
+            }
+            return;
+        }
+
+        $pages = $response->json()['query']['pages'] ?? [];
+
+        foreach ($pages as $page) {
+            $title = $page['title'] ?? '';
+            $extract = $page['extract'] ?? '';
+
+            if (!$title || str_starts_with($title, 'Category:')) continue;
+
+            // Skip disambiguation pages and lists
+            if (str_contains(strtolower($extract), 'may refer to') ||
+                str_contains(strtolower($title), 'list of')) continue;
+
+            $description = $extract ? substr(trim($extract), 0, 500) : null;
+
+            $this->upsertCompany([
+                'name' => $title,
+                'status' => $status,
+                'description' => $description,
+                'country' => 'US',
+            ]);
+        }
+    }
+}


### PR DESCRIPTION
## New Importers

### Wikipedia Acquisitions Importer (`wikipedia-acquisitions`)
Parses M&A lists for 12 major tech acquirers (Alphabet, Apple, Meta, Microsoft, Amazon, Salesforce, Oracle, Cisco, IBM, Intel, Yahoo!, Twitter). **578 companies created.**

### Wikipedia Defunct Companies Importer (`wikipedia-defunct`)
Fetches defunct software and technology companies from Wikipedia categories. **1,040 companies created.**

### Wikipedia Category Importer (`wikipedia-categories`)
Imports companies from year-based categories (tech companies established 2020-2025, American companies established 2020-2025). **302 companies created.**

### GitHub Organizations Importer (`github-orgs`)
Searches GitHub for organizations in major tech cities. Supports `GITHUB_TOKEN` env var for higher rate limits. **21 companies created** (limited by unauthenticated rate limits; set GITHUB_TOKEN for full import).

### Import Stats
| Source | Created | Updated | Skipped | Total |
|--------|---------|---------|---------|-------|
| wikipedia-acquisitions | 578 | 16 | 2 | 596 |
| wikipedia-defunct | 1,040 | 24 | 0 | 1,064 |
| wikipedia-categories | 301 | 25 | 3 | 329 |
| github-orgs | 21 | - | - | ~21 |

**Total companies in database: 8,441**