### PR TITLE
Import 58 remote-first companies from AsyncWorldwide.com

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.3'
+          php-version: '8.4'
           extensions: mbstring, xml, sqlite3
           coverage: none
       - run: composer install --no-progress --prefer-dist
@@ -24,6 +24,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.3'
+          php-version: '8.4'
       - run: composer install --no-progress --prefer-dist
       - run: vendor/bin/pint --test

--- a/app/Console/Commands/AuditCompanyData.php
+++ b/app/Console/Commands/AuditCompanyData.php
@@ -8,6 +8,7 @@ use Illuminate\Console\Command;
 class AuditCompanyData extends Command
 {
     protected $signature = 'companies:audit';
+
     protected $description = 'Audit company data completeness and report missing fields';
 
     public function handle(): int

--- a/app/Console/Commands/BulkImportCompanies.php
+++ b/app/Console/Commands/BulkImportCompanies.php
@@ -49,17 +49,19 @@ class BulkImportCompanies extends Command
         $source = $this->option('source');
         $all = $this->option('all');
 
-        if (!$source && !$all) {
+        if (! $source && ! $all) {
             $this->error('Specify --source=<name> or --all');
-            $this->line('Available sources: ' . implode(', ', array_keys($this->importers)));
+            $this->line('Available sources: '.implode(', ', array_keys($this->importers)));
+
             return 1;
         }
 
         $sources = $all ? array_keys($this->importers) : [$source];
 
         foreach ($sources as $src) {
-            if (!isset($this->importers[$src])) {
+            if (! isset($this->importers[$src])) {
                 $this->error("Unknown source: {$src}");
+
                 continue;
             }
 
@@ -97,7 +99,7 @@ class BulkImportCompanies extends Command
 
         if ($source === 'crunchbase') {
             $file = $this->option('file');
-            if (!$file) {
+            if (! $file) {
                 throw new \RuntimeException('--file is required for crunchbase source');
             }
             $options['file'] = $file;
@@ -122,7 +124,7 @@ class BulkImportCompanies extends Command
                 $options['resume_offset'] = (int) ($lastImport->last_offset ?? 0);
                 $options['resume_cursor'] = $lastImport->last_offset;
                 $options['resume_from'] = (int) ($lastImport->last_offset ?? 0);
-                $this->info("Resuming from last checkpoint");
+                $this->info('Resuming from last checkpoint');
             }
         }
 

--- a/app/Console/Commands/CheckFundingDuplicates.php
+++ b/app/Console/Commands/CheckFundingDuplicates.php
@@ -29,7 +29,7 @@ class CheckFundingDuplicates extends Command
      */
     public function handle(): int
     {
-        $service = new FundingRoundDeduplicationService();
+        $service = new FundingRoundDeduplicationService;
 
         // Apply custom tolerances if provided
         $dateTolerance = (int) $this->option('date-tolerance');
@@ -38,9 +38,9 @@ class CheckFundingDuplicates extends Command
         $service->setDateTolerance($dateTolerance);
         $service->setAmountTolerance($amountTolerance);
 
-        $this->info("Checking for potential duplicate funding rounds...");
+        $this->info('Checking for potential duplicate funding rounds...');
         $this->info("Date tolerance: {$dateTolerance} days");
-        $this->info("Amount tolerance: " . ($amountTolerance * 100) . "%");
+        $this->info('Amount tolerance: '.($amountTolerance * 100).'%');
         $this->newLine();
 
         if ($companySlug = $this->option('company')) {
@@ -57,8 +57,9 @@ class CheckFundingDuplicates extends Command
     {
         $company = \App\Models\Company::where('slug', $slug)->first();
 
-        if (!$company) {
+        if (! $company) {
             $this->error("Company with slug '{$slug}' not found.");
+
             return 1;
         }
 
@@ -66,10 +67,11 @@ class CheckFundingDuplicates extends Command
 
         if ($duplicates->isEmpty()) {
             $this->info("No potential duplicates found for {$company->name}.");
+
             return 0;
         }
 
-        $this->warn("Found " . $duplicates->count() . " potential duplicate pair(s) for {$company->name}:");
+        $this->warn('Found '.$duplicates->count()." potential duplicate pair(s) for {$company->name}:");
         $this->newLine();
 
         $this->outputDuplicates($duplicates);
@@ -85,16 +87,17 @@ class CheckFundingDuplicates extends Command
         $results = $service->findAllDuplicates();
 
         if ($results->isEmpty()) {
-            $this->info("No potential duplicates found across all companies.");
+            $this->info('No potential duplicates found across all companies.');
+
             return 0;
         }
 
-        $totalPairs = $results->sum(fn($r) => $r['duplicates']->count());
-        $this->warn("Found {$totalPairs} potential duplicate pair(s) across " . $results->count() . " company(ies):");
+        $totalPairs = $results->sum(fn ($r) => $r['duplicates']->count());
+        $this->warn("Found {$totalPairs} potential duplicate pair(s) across ".$results->count().' company(ies):');
         $this->newLine();
 
         foreach ($results as $result) {
-            $this->info("Company: " . $result['company']->name);
+            $this->info('Company: '.$result['company']->name);
             $this->outputDuplicates($result['duplicates']);
             $this->newLine();
         }
@@ -140,13 +143,13 @@ class CheckFundingDuplicates extends Command
         }
 
         if ($amount >= 1_000_000_000) {
-            return '$' . round($amount / 1_000_000_000, 2) . 'B';
+            return '$'.round($amount / 1_000_000_000, 2).'B';
         }
 
         if ($amount >= 1_000_000) {
-            return '$' . round($amount / 1_000_000, 1) . 'M';
+            return '$'.round($amount / 1_000_000, 1).'M';
         }
 
-        return '$' . number_format($amount);
+        return '$'.number_format($amount);
     }
 }

--- a/app/Console/Commands/DiscoverCompanies.php
+++ b/app/Console/Commands/DiscoverCompanies.php
@@ -22,37 +22,38 @@ class DiscoverCompanies extends Command
 
         $available = $service->getAvailableSources();
 
-        if ($source !== 'all' && !in_array($source, $available)) {
-            $this->error("Unknown source '{$source}'. Available: " . implode(', ', $available));
+        if ($source !== 'all' && ! in_array($source, $available)) {
+            $this->error("Unknown source '{$source}'. Available: ".implode(', ', $available));
+
             return self::FAILURE;
         }
 
         $this->info('🔍 Discovering companies...');
-        $this->info("   Source: {$source} | Days: {$days}" . ($dryRun ? ' | DRY RUN' : ''));
+        $this->info("   Source: {$source} | Days: {$days}".($dryRun ? ' | DRY RUN' : ''));
         $this->newLine();
 
         $results = $service->run($source, $days, $dryRun);
 
         // Show discovered
-        $this->info("📊 Discovered: " . count($results['discovered']) . " candidates");
+        $this->info('📊 Discovered: '.count($results['discovered']).' candidates');
 
         // Show existing
-        if (!empty($results['existing'])) {
-            $this->line("   Already known: " . count($results['existing']));
+        if (! empty($results['existing'])) {
+            $this->line('   Already known: '.count($results['existing']));
             foreach ($results['existing'] as $item) {
                 $this->line("   ├─ {$item['name']} ({$item['source']})");
             }
         }
 
         // Show created/would-create
-        if (!empty($results['created'])) {
+        if (! empty($results['created'])) {
             $label = $dryRun ? 'Would add' : 'Added';
-            $this->info("   ✅ {$label}: " . count($results['created']));
+            $this->info("   ✅ {$label}: ".count($results['created']));
             foreach ($results['created'] as $item) {
                 $name = $item['name'];
                 $extra = [];
                 if (isset($item['funding_amount'])) {
-                    $extra[] = '$' . number_format($item['funding_amount']);
+                    $extra[] = '$'.number_format($item['funding_amount']);
                 }
                 if (isset($item['funding_round'])) {
                     $extra[] = $item['funding_round'];
@@ -60,17 +61,17 @@ class DiscoverCompanies extends Command
                 if (isset($item['batch'])) {
                     $extra[] = $item['batch'];
                 }
-                $suffix = $extra ? ' (' . implode(', ', $extra) . ')' : '';
+                $suffix = $extra ? ' ('.implode(', ', $extra).')' : '';
                 $this->line("   ├─ {$name}{$suffix} [{$item['source']}]");
             }
         } else {
-            $this->line("   No new companies found.");
+            $this->line('   No new companies found.');
         }
 
         // Show errors
-        if (!empty($results['errors'])) {
+        if (! empty($results['errors'])) {
             $this->newLine();
-            $this->warn("⚠️  Errors:");
+            $this->warn('⚠️  Errors:');
             foreach ($results['errors'] as $error) {
                 $this->warn("   {$error}");
             }

--- a/app/Console/Commands/DiscoverOssProjects.php
+++ b/app/Console/Commands/DiscoverOssProjects.php
@@ -8,6 +8,7 @@ use Illuminate\Console\Command;
 class DiscoverOssProjects extends Command
 {
     protected $signature = 'app:discover-oss-projects';
+
     protected $description = 'Discover open-source projects from GitHub topics and awesome-selfhosted';
 
     public function handle(GitHubDiscoveryService $service): int

--- a/app/Console/Commands/DispatchDailyHeadcounts.php
+++ b/app/Console/Commands/DispatchDailyHeadcounts.php
@@ -30,13 +30,14 @@ class DispatchDailyHeadcounts extends Command
 
         if ($this->option('assign-only')) {
             $this->showDistribution();
+
             return self::SUCCESS;
         }
 
         // Get companies to process
         $query = Company::whereNotNull('linkedin_url');
 
-        if (!$this->option('force')) {
+        if (! $this->option('force')) {
             $query->where('headcount_fetch_day', $dayOfMonth);
         }
 
@@ -44,6 +45,7 @@ class DispatchDailyHeadcounts extends Command
 
         if ($companies->isEmpty()) {
             $this->info("No companies scheduled for day {$dayOfMonth}.");
+
             return self::SUCCESS;
         }
 
@@ -53,7 +55,7 @@ class DispatchDailyHeadcounts extends Command
             // Stagger jobs by 3 seconds each to avoid LinkedIn rate limiting
             $delay = $index * 3;
             FetchCompanyHeadcountJob::dispatch($company)->delay(now()->addSeconds($delay));
-            $this->line("  Dispatched: {$company->name}" . ($delay > 0 ? " (delay: {$delay}s)" : ''));
+            $this->line("  Dispatched: {$company->name}".($delay > 0 ? " (delay: {$delay}s)" : ''));
         }
 
         $this->newLine();
@@ -82,7 +84,7 @@ class DispatchDailyHeadcounts extends Command
 
         // Fill in missing days with 0
         for ($day = 1; $day <= 25; $day++) {
-            if (!isset($distribution[$day])) {
+            if (! isset($distribution[$day])) {
                 $distribution[$day] = 0;
             }
         }

--- a/app/Console/Commands/FetchLinkedInHeadcounts.php
+++ b/app/Console/Commands/FetchLinkedInHeadcounts.php
@@ -28,6 +28,7 @@ class FetchLinkedInHeadcounts extends Command
 
         if ($companies->isEmpty()) {
             $this->warn('No companies with LinkedIn URLs found.');
+
             return self::SUCCESS;
         }
 
@@ -42,9 +43,10 @@ class FetchLinkedInHeadcounts extends Command
 
             $result = $linkedInService->fetchHeadcount($company->linkedin_url);
 
-            if (!$result['success']) {
+            if (! $result['success']) {
                 $this->error("  Failed: {$result['error']}");
                 $failed++;
+
                 continue;
             }
 
@@ -52,7 +54,8 @@ class FetchLinkedInHeadcounts extends Command
             $this->info("  Found: {$headcount} employees");
 
             if ($this->option('dry-run')) {
-                $this->comment("  [Dry run - not saving]");
+                $this->comment('  [Dry run - not saving]');
+
                 continue;
             }
 
@@ -67,16 +70,16 @@ class FetchLinkedInHeadcounts extends Command
                 ->orderBy('recorded_date', 'desc')
                 ->first();
 
-            if (!$lastSnapshot || $lastSnapshot->headcount !== $headcount) {
+            if (! $lastSnapshot || $lastSnapshot->headcount !== $headcount) {
                 HeadcountSnapshot::create([
                     'company_id' => $company->id,
                     'headcount' => $headcount,
                     'recorded_date' => now()->toDateString(),
                     'source' => 'linkedin',
                 ]);
-                $this->info("  Saved new snapshot");
+                $this->info('  Saved new snapshot');
             } else {
-                $this->comment("  Headcount unchanged, skipping snapshot");
+                $this->comment('  Headcount unchanged, skipping snapshot');
             }
 
             $updated++;

--- a/app/Console/Commands/FetchNews.php
+++ b/app/Console/Commands/FetchNews.php
@@ -41,8 +41,9 @@ class FetchNews extends Command
             ->orWhere('name', 'LIKE', "%{$escapedIdentifier}%")
             ->first();
 
-        if (!$company) {
+        if (! $company) {
             $this->error("Company not found: {$identifier}");
+
             return self::FAILURE;
         }
 
@@ -69,6 +70,7 @@ class FetchNews extends Command
 
         if ($total === 0) {
             $this->info('No companies found.');
+
             return self::SUCCESS;
         }
 
@@ -87,7 +89,7 @@ class FetchNews extends Command
                 $delaySeconds = $index * $delay;
                 FetchNewsMentionsJob::dispatch($company)->delay(now()->addSeconds($delaySeconds));
 
-                $this->line("  Dispatched: {$company->name}" . ($delaySeconds > 0 ? " (delay: {$delaySeconds}s)" : ''));
+                $this->line("  Dispatched: {$company->name}".($delaySeconds > 0 ? " (delay: {$delaySeconds}s)" : ''));
                 $index++;
             }
 

--- a/app/Console/Commands/ImportCsv.php
+++ b/app/Console/Commands/ImportCsv.php
@@ -18,18 +18,19 @@ class ImportCsv extends Command
         $path = $this->argument('path');
         $source = $this->option('source');
 
-        if (!file_exists($path)) {
+        if (! file_exists($path)) {
             $this->error("File not found: {$path}");
+
             return 1;
         }
 
         $this->info("Importing companies from CSV: {$path} (source: {$source})");
 
-        $importer = new CrunchbaseCsvImporter();
+        $importer = new CrunchbaseCsvImporter;
         $importLog = $importer->start(['file' => $path]);
         $stats = $importer->getStats();
 
-        $this->info("✅ CSV import complete:");
+        $this->info('✅ CSV import complete:');
         $this->table(
             ['Metric', 'Count'],
             [

--- a/app/Console/Commands/McpServer.php
+++ b/app/Console/Commands/McpServer.php
@@ -15,6 +15,7 @@ use Illuminate\Console\Command;
 class McpServer extends Command
 {
     protected $signature = 'mcp:serve';
+
     protected $description = 'Start an MCP (Model Context Protocol) server for AI tool integration';
 
     private array $tools = [
@@ -68,16 +69,21 @@ class McpServer extends Command
 
         while (($line = fgets($stdin)) !== false) {
             $line = trim($line);
-            if (empty($line)) continue;
+            if (empty($line)) {
+                continue;
+            }
 
             $request = json_decode($line, true);
-            if (! $request) continue;
+            if (! $request) {
+                continue;
+            }
 
             $response = $this->handleRequest($request);
-            fwrite(STDOUT, json_encode($response) . "\n");
+            fwrite(STDOUT, json_encode($response)."\n");
         }
 
         fclose($stdin);
+
         return 0;
     }
 
@@ -127,12 +133,16 @@ class McpServer extends Command
             $escaped = str_replace(['%', '_'], ['\%', '\_'], $q);
             $query->where(function ($qb) use ($escaped) {
                 $qb->where('name', 'like', "%{$escaped}%")
-                   ->orWhere('description', 'like', "%{$escaped}%");
+                    ->orWhere('description', 'like', "%{$escaped}%");
             });
         }
 
-        if ($cat = ($args['category'] ?? null)) $query->where('category', $cat);
-        if ($country = ($args['country'] ?? null)) $query->where('country', $country);
+        if ($cat = ($args['category'] ?? null)) {
+            $query->where('category', $cat);
+        }
+        if ($country = ($args['country'] ?? null)) {
+            $query->where('country', $country);
+        }
 
         return $query->orderBy('name')
             ->limit(min($args['limit'] ?? 10, 50))

--- a/app/Console/Commands/RecordHeadcount.php
+++ b/app/Console/Commands/RecordHeadcount.php
@@ -28,8 +28,9 @@ class RecordHeadcount extends Command
             ->orWhere('name', 'like', "%{$companyInput}%")
             ->first();
 
-        if (!$company) {
+        if (! $company) {
             $this->error("Company not found: {$companyInput}");
+
             return 1;
         }
 

--- a/app/Console/Commands/RefreshOssStars.php
+++ b/app/Console/Commands/RefreshOssStars.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Facades\Log;
 class RefreshOssStars extends Command
 {
     protected $signature = 'app:refresh-oss-stars {--limit=0 : Max projects to refresh (0 = all)}';
+
     protected $description = 'Refresh star counts, forks, and last commit dates for all OSS projects';
 
     public function handle(): int
@@ -61,6 +62,7 @@ class RefreshOssStars extends Command
                     $waitSeconds = $resetAt ? max(1, (int) $resetAt - time()) : 60;
                     $this->warn("\nRate limited. Waiting {$waitSeconds}s...");
                     sleep(min($waitSeconds, 300));
+
                     continue;
                 } else {
                     Log::debug("Failed to refresh {$project->github_owner}/{$project->github_repo}: {$response->status()}");

--- a/app/Console/Commands/SchedulingStatus.php
+++ b/app/Console/Commands/SchedulingStatus.php
@@ -50,6 +50,7 @@ class SchedulingStatus extends Command
         if ($stats->isEmpty()) {
             $this->comment('No task executions found.');
             $this->newLine();
+
             return;
         }
 
@@ -57,8 +58,9 @@ class SchedulingStatus extends Command
             ['Task Type', 'Total', 'Success', 'Failed', 'Running', 'Success Rate'],
             $stats->map(function ($row) {
                 $rate = $row->total > 0
-                    ? round(($row->success / $row->total) * 100, 1) . '%'
+                    ? round(($row->success / $row->total) * 100, 1).'%'
                     : 'N/A';
+
                 return [
                     $row->task_type,
                     $row->total,
@@ -75,7 +77,7 @@ class SchedulingStatus extends Command
 
     private function showRecentFailures(int $days, ?string $taskType): void
     {
-        $this->info("=== Recent Failures ===");
+        $this->info('=== Recent Failures ===');
         $this->newLine();
 
         $query = ScheduledTaskExecution::recent($days)
@@ -93,6 +95,7 @@ class SchedulingStatus extends Command
         if ($failures->isEmpty()) {
             $this->comment('No failures found. Great!');
             $this->newLine();
+
             return;
         }
 
@@ -102,7 +105,7 @@ class SchedulingStatus extends Command
                 $companyName = $execution->company?->name ?? 'N/A';
                 $error = $execution->error_message
                     ? (strlen($execution->error_message) > 50
-                        ? substr($execution->error_message, 0, 47) . '...'
+                        ? substr($execution->error_message, 0, 47).'...'
                         : $execution->error_message)
                     : 'Unknown error';
 
@@ -120,7 +123,7 @@ class SchedulingStatus extends Command
 
     private function showCompanyDistribution(): void
     {
-        $this->info("=== Company Distribution by Fetch Day ===");
+        $this->info('=== Company Distribution by Fetch Day ===');
         $this->newLine();
 
         $withLinkedIn = Company::whereNotNull('linkedin_url')->count();
@@ -137,6 +140,7 @@ class SchedulingStatus extends Command
         if ($assigned === 0) {
             $this->comment('No companies assigned yet. Run: php artisan schedule:headcounts --assign-only');
             $this->newLine();
+
             return;
         }
 
@@ -157,7 +161,7 @@ class SchedulingStatus extends Command
         }
 
         foreach ($rows as $row) {
-            $this->line('  ' . implode('  |  ', $row));
+            $this->line('  '.implode('  |  ', $row));
         }
 
         $this->newLine();

--- a/app/Console/Commands/ScrapeTechCrunchFunding.php
+++ b/app/Console/Commands/ScrapeTechCrunchFunding.php
@@ -2,7 +2,6 @@
 
 namespace App\Console\Commands;
 
-use App\Models\Company;
 use App\Models\FundingRound;
 use App\Models\ScheduledTaskExecution;
 use App\Services\TechCrunchService;
@@ -20,7 +19,7 @@ class ScrapeTechCrunchFunding extends Command
         $isDryRun = $this->option('dry-run');
 
         $execution = null;
-        if (!$isDryRun) {
+        if (! $isDryRun) {
             $execution = ScheduledTaskExecution::create([
                 'task_type' => 'funding_scrape',
                 'status' => 'running',
@@ -33,12 +32,12 @@ class ScrapeTechCrunchFunding extends Command
 
             $result = $techCrunchService->scrapeFundraisingArticles();
 
-            if (!$result['success']) {
+            if (! $result['success']) {
                 throw new \RuntimeException($result['error'] ?? 'Failed to scrape TechCrunch');
             }
 
             $articles = $result['articles'];
-            $this->info("Found " . count($articles) . " funding-related articles.");
+            $this->info('Found '.count($articles).' funding-related articles.');
 
             if (empty($articles)) {
                 $execution?->update([
@@ -47,6 +46,7 @@ class ScrapeTechCrunchFunding extends Command
                     'metadata' => ['articles_found' => 0, 'matches' => 0, 'created' => 0],
                 ]);
                 $this->info('No articles to process.');
+
                 return self::SUCCESS;
             }
 
@@ -65,6 +65,7 @@ class ScrapeTechCrunchFunding extends Command
                     ],
                 ]);
                 $this->info('No matches found for tracked companies.');
+
                 return self::SUCCESS;
             }
 
@@ -78,7 +79,7 @@ class ScrapeTechCrunchFunding extends Command
 
                 $fundingInfo = $match['funding_info'];
                 if (isset($fundingInfo['amount'])) {
-                    $this->line("Amount: $" . number_format($fundingInfo['amount']));
+                    $this->line('Amount: $'.number_format($fundingInfo['amount']));
                 }
                 if (isset($fundingInfo['round_type'])) {
                     $this->line("Round: {$fundingInfo['round_type']}");
@@ -86,6 +87,7 @@ class ScrapeTechCrunchFunding extends Command
 
                 if ($isDryRun) {
                     $this->comment('[Dry run - not saving]');
+
                     continue;
                 }
 
@@ -97,6 +99,7 @@ class ScrapeTechCrunchFunding extends Command
                 if ($exists) {
                     $this->comment('  Already exists, skipping.');
                     $skipped++;
+
                     continue;
                 }
 
@@ -138,6 +141,7 @@ class ScrapeTechCrunchFunding extends Command
             ]);
 
             $this->error("Error: {$e->getMessage()}");
+
             return self::FAILURE;
         }
     }

--- a/app/Contracts/CompanyDiscoverySource.php
+++ b/app/Contracts/CompanyDiscoverySource.php
@@ -12,7 +12,7 @@ interface CompanyDiscoverySource
     /**
      * Discover companies from this source.
      *
-     * @param int $days How many days back to look
+     * @param  int  $days  How many days back to look
      * @return array<int, array{name: string, description?: string, website?: string, funding_amount?: float, funding_round?: string, source_url?: string, batch?: string}>
      */
     public function discover(int $days = 7): array;

--- a/app/Http/Controllers/Admin/CompanyController.php
+++ b/app/Http/Controllers/Admin/CompanyController.php
@@ -6,8 +6,8 @@ use App\Http\Controllers\Controller;
 use App\Models\Company;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
-use Illuminate\Support\Str;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
 use Illuminate\Validation\Rule;
 use Illuminate\View\View;
 
@@ -24,8 +24,8 @@ class CompanyController extends Controller
             $escapedSearch = str_replace(['%', '_'], ['\%', '\_'], $search);
             $query->where(function ($q) use ($escapedSearch) {
                 $q->where('name', 'like', "%{$escapedSearch}%")
-                  ->orWhere('city', 'like', "%{$escapedSearch}%")
-                  ->orWhere('country', 'like', "%{$escapedSearch}%");
+                    ->orWhere('city', 'like', "%{$escapedSearch}%")
+                    ->orWhere('country', 'like', "%{$escapedSearch}%");
             });
         }
 
@@ -68,7 +68,7 @@ class CompanyController extends Controller
         $originalSlug = $slug;
         $counter = 1;
         while (Company::where('slug', $slug)->exists()) {
-            $slug = $originalSlug . '-' . $counter;
+            $slug = $originalSlug.'-'.$counter;
             $counter++;
         }
 

--- a/app/Http/Controllers/Admin/OssProjectController.php
+++ b/app/Http/Controllers/Admin/OssProjectController.php
@@ -3,11 +3,11 @@
 namespace App\Http\Controllers\Admin;
 
 use App\Http\Controllers\Controller;
-use App\Models\OpenSourceProject;
 use App\Models\Company;
+use App\Models\OpenSourceProject;
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\View\View;
-use Illuminate\Http\RedirectResponse;
 
 class OssProjectController extends Controller
 {
@@ -19,8 +19,8 @@ class OssProjectController extends Controller
             $escaped = str_replace(['%', '_'], ['\%', '\_'], $search);
             $query->where(function ($q) use ($escaped) {
                 $q->where('name', 'like', "%{$escaped}%")
-                  ->orWhere('github_owner', 'like', "%{$escaped}%")
-                  ->orWhere('description', 'like', "%{$escaped}%");
+                    ->orWhere('github_owner', 'like', "%{$escaped}%")
+                    ->orWhere('description', 'like', "%{$escaped}%");
             });
         }
 

--- a/app/Http/Controllers/Api/CompanyController.php
+++ b/app/Http/Controllers/Api/CompanyController.php
@@ -25,16 +25,16 @@ class CompanyController extends Controller
             ->addSelect(['latest_funding_date' => FundingRound::select('announced_date')
                 ->whereColumn('company_id', 'companies.id')
                 ->orderBy('announced_date', 'desc')
-                ->limit(1)
+                ->limit(1),
             ]);
 
         // Search by name, description, city, country
         if ($search = $request->get('q')) {
             $query->where(function ($q) use ($search) {
                 $q->where('name', 'like', "%{$search}%")
-                  ->orWhere('description', 'like', "%{$search}%")
-                  ->orWhere('city', 'like', "%{$search}%")
-                  ->orWhere('country', 'like', "%{$search}%");
+                    ->orWhere('description', 'like', "%{$search}%")
+                    ->orWhere('city', 'like', "%{$search}%")
+                    ->orWhere('country', 'like', "%{$search}%");
             });
         }
 
@@ -206,14 +206,15 @@ class CompanyController extends Controller
     private function formatAmount(float $amount): string
     {
         if ($amount >= 1_000_000_000) {
-            return '$' . number_format($amount / 1_000_000_000, 1) . 'B';
+            return '$'.number_format($amount / 1_000_000_000, 1).'B';
         }
         if ($amount >= 1_000_000) {
-            return '$' . number_format($amount / 1_000_000, 1) . 'M';
+            return '$'.number_format($amount / 1_000_000, 1).'M';
         }
         if ($amount >= 1_000) {
-            return '$' . number_format($amount / 1_000, 0) . 'K';
+            return '$'.number_format($amount / 1_000, 0).'K';
         }
-        return '$' . number_format($amount, 0);
+
+        return '$'.number_format($amount, 0);
     }
 }

--- a/app/Http/Controllers/Api/OssProjectController.php
+++ b/app/Http/Controllers/Api/OssProjectController.php
@@ -17,7 +17,7 @@ class OssProjectController extends Controller
             $escaped = str_replace(['%', '_'], ['\%', '\_'], $q);
             $query->where(function ($qb) use ($escaped) {
                 $qb->where('name', 'like', "%{$escaped}%")
-                   ->orWhere('description', 'like', "%{$escaped}%");
+                    ->orWhere('description', 'like', "%{$escaped}%");
             });
         }
 

--- a/app/Http/Controllers/Api/SearchController.php
+++ b/app/Http/Controllers/Api/SearchController.php
@@ -4,7 +4,6 @@ namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
 use App\Http\Resources\CompanySummaryResource;
-use App\Http\Resources\PersonSummaryResource;
 use App\Models\Company;
 use App\Models\FundingRound;
 use App\Models\Person;
@@ -38,18 +37,18 @@ class SearchController extends Controller
         $companies = Company::query()
             ->where(function ($q) use ($query) {
                 $q->where('name', 'like', "%{$query}%")
-                  ->orWhere('description', 'like', "%{$query}%")
-                  ->orWhere('city', 'like', "%{$query}%")
-                  ->orWhere('country', 'like', "%{$query}%");
+                    ->orWhere('description', 'like', "%{$query}%")
+                    ->orWhere('city', 'like', "%{$query}%")
+                    ->orWhere('country', 'like', "%{$query}%");
             })
             ->withSum('fundingRounds', 'amount')
             ->withCount('fundingRounds')
             ->addSelect(['latest_funding_date' => FundingRound::select('announced_date')
                 ->whereColumn('company_id', 'companies.id')
                 ->orderBy('announced_date', 'desc')
-                ->limit(1)
+                ->limit(1),
             ])
-            ->orderByRaw("CASE WHEN name LIKE ? THEN 0 ELSE 1 END", ["{$query}%"])
+            ->orderByRaw('CASE WHEN name LIKE ? THEN 0 ELSE 1 END', ["{$query}%"])
             ->orderBy('name')
             ->limit($limit)
             ->get();
@@ -58,10 +57,10 @@ class SearchController extends Controller
         $people = Person::query()
             ->where(function ($q) use ($query) {
                 $q->where('name', 'like', "%{$query}%")
-                  ->orWhere('bio', 'like', "%{$query}%");
+                    ->orWhere('bio', 'like', "%{$query}%");
             })
             ->with(['companies' => fn ($q) => $q->wherePivot('is_current', true)->limit(1)])
-            ->orderByRaw("CASE WHEN name LIKE ? THEN 0 ELSE 1 END", ["{$query}%"])
+            ->orderByRaw('CASE WHEN name LIKE ? THEN 0 ELSE 1 END', ["{$query}%"])
             ->orderBy('name')
             ->limit($limit)
             ->get();

--- a/app/Http/Controllers/Api/StatsController.php
+++ b/app/Http/Controllers/Api/StatsController.php
@@ -36,14 +36,15 @@ class StatsController extends Controller
     private function formatAmount(float $amount): string
     {
         if ($amount >= 1_000_000_000) {
-            return '$' . number_format($amount / 1_000_000_000, 1) . 'B';
+            return '$'.number_format($amount / 1_000_000_000, 1).'B';
         }
         if ($amount >= 1_000_000) {
-            return '$' . number_format($amount / 1_000_000, 1) . 'M';
+            return '$'.number_format($amount / 1_000_000, 1).'M';
         }
         if ($amount >= 1_000) {
-            return '$' . number_format($amount / 1_000, 0) . 'K';
+            return '$'.number_format($amount / 1_000, 0).'K';
         }
-        return '$' . number_format($amount, 0);
+
+        return '$'.number_format($amount, 0);
     }
 }

--- a/app/Http/Controllers/CompanyController.php
+++ b/app/Http/Controllers/CompanyController.php
@@ -18,16 +18,16 @@ class CompanyController extends Controller
             ->addSelect(['latest_funding_date' => FundingRound::select('announced_date')
                 ->whereColumn('company_id', 'companies.id')
                 ->orderBy('announced_date', 'desc')
-                ->limit(1)
+                ->limit(1),
             ]);
 
         if ($search = $request->get('search')) {
             $escapedSearch = str_replace(['%', '_'], ['\%', '\_'], $search);
             $query->where(function ($q) use ($escapedSearch) {
                 $q->where('name', 'like', "%{$escapedSearch}%")
-                  ->orWhere('description', 'like', "%{$escapedSearch}%")
-                  ->orWhere('city', 'like', "%{$escapedSearch}%")
-                  ->orWhere('country', 'like', "%{$escapedSearch}%");
+                    ->orWhere('description', 'like', "%{$escapedSearch}%")
+                    ->orWhere('city', 'like', "%{$escapedSearch}%")
+                    ->orWhere('country', 'like', "%{$escapedSearch}%");
             });
         }
 
@@ -109,7 +109,7 @@ class CompanyController extends Controller
             fclose($handle);
         };
 
-        $filename = 'startupgraph-export-' . now()->format('Y-m-d') . '.csv';
+        $filename = 'startupgraph-export-'.now()->format('Y-m-d').'.csv';
 
         return response()->streamDownload($callback, $filename, [
             'Content-Type' => 'text/csv',
@@ -147,7 +147,7 @@ class CompanyController extends Controller
                 ];
             });
 
-        $filename = 'startupgraph-export-' . now()->format('Y-m-d') . '.json';
+        $filename = 'startupgraph-export-'.now()->format('Y-m-d').'.json';
 
         return response()->streamDownload(function () use ($companies) {
             echo json_encode(['companies' => $companies], JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE);
@@ -166,9 +166,9 @@ class CompanyController extends Controller
             $escapedSearch = str_replace(['%', '_'], ['\%', '\_'], $search);
             $query->where(function ($q) use ($escapedSearch) {
                 $q->where('name', 'like', "%{$escapedSearch}%")
-                  ->orWhere('description', 'like', "%{$escapedSearch}%")
-                  ->orWhere('city', 'like', "%{$escapedSearch}%")
-                  ->orWhere('country', 'like', "%{$escapedSearch}%");
+                    ->orWhere('description', 'like', "%{$escapedSearch}%")
+                    ->orWhere('city', 'like', "%{$escapedSearch}%")
+                    ->orWhere('country', 'like', "%{$escapedSearch}%");
             });
         }
 

--- a/app/Http/Controllers/CompareController.php
+++ b/app/Http/Controllers/CompareController.php
@@ -16,7 +16,7 @@ class CompareController extends Controller
         ));
 
         $companies = collect();
-        if (!empty($slugs)) {
+        if (! empty($slugs)) {
             $companies = Company::whereIn('slug', $slugs)
                 ->with(['fundingRounds.investors', 'headcountSnapshots'])
                 ->withSum('fundingRounds', 'amount')

--- a/app/Http/Controllers/InvestorController.php
+++ b/app/Http/Controllers/InvestorController.php
@@ -16,7 +16,7 @@ class InvestorController extends Controller
             $escaped = str_replace(['%', '_'], ['\%', '\_'], $search);
             $query->where(function ($q) use ($escaped) {
                 $q->where('name', 'like', "%{$escaped}%")
-                  ->orWhere('description', 'like', "%{$escaped}%");
+                    ->orWhere('description', 'like', "%{$escaped}%");
             });
         }
 

--- a/app/Http/Controllers/OpenSourceController.php
+++ b/app/Http/Controllers/OpenSourceController.php
@@ -16,8 +16,8 @@ class OpenSourceController extends Controller
             $escaped = str_replace(['%', '_'], ['\%', '\_'], $search);
             $query->where(function ($q) use ($escaped) {
                 $q->where('name', 'like', "%{$escaped}%")
-                  ->orWhere('description', 'like', "%{$escaped}%")
-                  ->orWhere('primary_language', 'like', "%{$escaped}%");
+                    ->orWhere('description', 'like', "%{$escaped}%")
+                    ->orWhere('primary_language', 'like', "%{$escaped}%");
             });
         }
 

--- a/app/Http/Controllers/PersonController.php
+++ b/app/Http/Controllers/PersonController.php
@@ -10,7 +10,7 @@ class PersonController extends Controller
     {
         $person->load(['companies' => function ($query) {
             $query->orderBy('company_person.is_current', 'desc')
-                  ->orderBy('company_person.started_at', 'desc');
+                ->orderBy('company_person.started_at', 'desc');
         }]);
 
         return view('people.show', compact('person'));

--- a/app/Http/Controllers/SavedSearchController.php
+++ b/app/Http/Controllers/SavedSearchController.php
@@ -34,7 +34,7 @@ class SavedSearchController extends Controller
         $savedSearch = Auth::user()->savedSearches()->create([
             'name' => $request->get('name'),
             'query' => $request->get('search'),
-            'filters_json' => !empty($filters) ? $filters : null,
+            'filters_json' => ! empty($filters) ? $filters : null,
             'notify_on_new' => $request->boolean('notify_on_new', false),
         ]);
 

--- a/app/Http/Controllers/SitemapController.php
+++ b/app/Http/Controllers/SitemapController.php
@@ -18,14 +18,14 @@ class SitemapController extends Controller
 
         // Static pages
         foreach (['/', '/companies', '/open-source', '/submit'] as $path) {
-            $xml .= '<url><loc>' . url($path) . '</loc><changefreq>daily</changefreq></url>';
+            $xml .= '<url><loc>'.url($path).'</loc><changefreq>daily</changefreq></url>';
         }
 
         // Company pages
         foreach ($companies as $company) {
             $xml .= '<url>';
-            $xml .= '<loc>' . route('companies.show', $company->slug) . '</loc>';
-            $xml .= '<lastmod>' . $company->updated_at->toW3cString() . '</lastmod>';
+            $xml .= '<loc>'.route('companies.show', $company->slug).'</loc>';
+            $xml .= '<lastmod>'.$company->updated_at->toW3cString().'</lastmod>';
             $xml .= '<changefreq>weekly</changefreq>';
             $xml .= '</url>';
         }

--- a/app/Http/Middleware/AdminAuth.php
+++ b/app/Http/Middleware/AdminAuth.php
@@ -3,8 +3,8 @@
 namespace App\Http\Middleware;
 
 use Closure;
-use Illuminate\Http\Request;
 use Illuminate\Cache\RateLimiter;
+use Illuminate\Http\Request;
 use Symfony\Component\HttpFoundation\Response;
 
 class AdminAuth
@@ -29,7 +29,7 @@ class AdminAuth
 
         // Rate limit by IP address
         $rateLimiter = app(RateLimiter::class);
-        $key = 'admin-auth:' . $request->ip();
+        $key = 'admin-auth:'.$request->ip();
 
         if ($rateLimiter->tooManyAttempts($key, 5)) {
             $retryAfter = $rateLimiter->availableIn($key);
@@ -43,7 +43,7 @@ class AdminAuth
         $providedUser = $request->getUser() ?? '';
         $providedPass = $request->getPassword() ?? '';
 
-        if (!hash_equals($username, $providedUser) || !hash_equals($password, $providedPass)) {
+        if (! hash_equals($username, $providedUser) || ! hash_equals($password, $providedPass)) {
             $rateLimiter->hit($key, 60);
 
             return response('Unauthorized.', 401, ['WWW-Authenticate' => 'Basic realm="Admin Area"']);

--- a/app/Http/Resources/CompanyResource.php
+++ b/app/Http/Resources/CompanyResource.php
@@ -28,13 +28,12 @@ class CompanyResource extends JsonResource
             'total_funding' => $this->whenNotNull($this->funding_rounds_sum_amount, fn () => (float) $this->funding_rounds_sum_amount),
             'total_funding_formatted' => $this->whenNotNull($this->funding_rounds_sum_amount, fn () => $this->formatAmount($this->funding_rounds_sum_amount)),
             'funding_rounds_count' => $this->funding_rounds_count ?? $this->fundingRounds?->count() ?? 0,
-            'latest_funding' => $this->whenLoaded('latestFundingRound', fn () =>
-                $this->latestFundingRound ? [
-                    'round_type' => $this->latestFundingRound->round_type,
-                    'amount' => $this->latestFundingRound->amount ? (float) $this->latestFundingRound->amount : null,
-                    'amount_formatted' => $this->latestFundingRound->amount ? $this->formatAmount($this->latestFundingRound->amount) : null,
-                    'announced_date' => $this->latestFundingRound->announced_date?->format('Y-m-d'),
-                ] : null
+            'latest_funding' => $this->whenLoaded('latestFundingRound', fn () => $this->latestFundingRound ? [
+                'round_type' => $this->latestFundingRound->round_type,
+                'amount' => $this->latestFundingRound->amount ? (float) $this->latestFundingRound->amount : null,
+                'amount_formatted' => $this->latestFundingRound->amount ? $this->formatAmount($this->latestFundingRound->amount) : null,
+                'announced_date' => $this->latestFundingRound->announced_date?->format('Y-m-d'),
+            ] : null
             ),
             'people_count' => $this->people?->count() ?? 0,
             'funding_rounds' => FundingRoundResource::collection($this->whenLoaded('fundingRounds')),
@@ -47,14 +46,15 @@ class CompanyResource extends JsonResource
     private function formatAmount(float $amount): string
     {
         if ($amount >= 1_000_000_000) {
-            return '$' . number_format($amount / 1_000_000_000, 1) . 'B';
+            return '$'.number_format($amount / 1_000_000_000, 1).'B';
         }
         if ($amount >= 1_000_000) {
-            return '$' . number_format($amount / 1_000_000, 1) . 'M';
+            return '$'.number_format($amount / 1_000_000, 1).'M';
         }
         if ($amount >= 1_000) {
-            return '$' . number_format($amount / 1_000, 0) . 'K';
+            return '$'.number_format($amount / 1_000, 0).'K';
         }
-        return '$' . number_format($amount, 0);
+
+        return '$'.number_format($amount, 0);
     }
 }

--- a/app/Http/Resources/CompanySummaryResource.php
+++ b/app/Http/Resources/CompanySummaryResource.php
@@ -29,14 +29,15 @@ class CompanySummaryResource extends JsonResource
     private function formatAmount(float $amount): string
     {
         if ($amount >= 1_000_000_000) {
-            return '$' . number_format($amount / 1_000_000_000, 1) . 'B';
+            return '$'.number_format($amount / 1_000_000_000, 1).'B';
         }
         if ($amount >= 1_000_000) {
-            return '$' . number_format($amount / 1_000_000, 1) . 'M';
+            return '$'.number_format($amount / 1_000_000, 1).'M';
         }
         if ($amount >= 1_000) {
-            return '$' . number_format($amount / 1_000, 0) . 'K';
+            return '$'.number_format($amount / 1_000, 0).'K';
         }
-        return '$' . number_format($amount, 0);
+
+        return '$'.number_format($amount, 0);
     }
 }

--- a/app/Http/Resources/FundingRoundResource.php
+++ b/app/Http/Resources/FundingRoundResource.php
@@ -17,13 +17,12 @@ class FundingRoundResource extends JsonResource
             'announced_date' => $this->announced_date?->format('Y-m-d'),
             'pre_money_valuation' => $this->pre_money_valuation ? (float) $this->pre_money_valuation : null,
             'source_url' => $this->source_url,
-            'investors' => $this->whenLoaded('investors', fn () =>
-                $this->investors->map(fn ($investor) => [
-                    'name' => $investor->name,
-                    'slug' => $investor->slug,
-                    'type' => $investor->type,
-                    'is_lead' => (bool) $investor->pivot->is_lead,
-                ])
+            'investors' => $this->whenLoaded('investors', fn () => $this->investors->map(fn ($investor) => [
+                'name' => $investor->name,
+                'slug' => $investor->slug,
+                'type' => $investor->type,
+                'is_lead' => (bool) $investor->pivot->is_lead,
+            ])
             ),
         ];
     }
@@ -31,14 +30,15 @@ class FundingRoundResource extends JsonResource
     private function formatAmount(float $amount): string
     {
         if ($amount >= 1_000_000_000) {
-            return '$' . number_format($amount / 1_000_000_000, 1) . 'B';
+            return '$'.number_format($amount / 1_000_000_000, 1).'B';
         }
         if ($amount >= 1_000_000) {
-            return '$' . number_format($amount / 1_000_000, 1) . 'M';
+            return '$'.number_format($amount / 1_000_000, 1).'M';
         }
         if ($amount >= 1_000) {
-            return '$' . number_format($amount / 1_000, 0) . 'K';
+            return '$'.number_format($amount / 1_000, 0).'K';
         }
-        return '$' . number_format($amount, 0);
+
+        return '$'.number_format($amount, 0);
     }
 }

--- a/app/Http/Resources/PersonResource.php
+++ b/app/Http/Resources/PersonResource.php
@@ -16,15 +16,14 @@ class PersonResource extends JsonResource
             'linkedin_url' => $this->linkedin_url,
             'twitter_url' => $this->twitter_url,
             'photo_url' => $this->photo_url,
-            'companies' => $this->whenLoaded('companies', fn () =>
-                $this->companies->map(fn ($company) => [
-                    'slug' => $company->slug,
-                    'name' => $company->name,
-                    'role' => $company->pivot->role,
-                    'is_current' => (bool) $company->pivot->is_current,
-                    'started_at' => $company->pivot->started_at,
-                    'ended_at' => $company->pivot->ended_at,
-                ])
+            'companies' => $this->whenLoaded('companies', fn () => $this->companies->map(fn ($company) => [
+                'slug' => $company->slug,
+                'name' => $company->name,
+                'role' => $company->pivot->role,
+                'is_current' => (bool) $company->pivot->is_current,
+                'started_at' => $company->pivot->started_at,
+                'ended_at' => $company->pivot->ended_at,
+            ])
             ),
         ];
     }

--- a/app/Jobs/FetchCompanyHeadcountJob.php
+++ b/app/Jobs/FetchCompanyHeadcountJob.php
@@ -18,6 +18,7 @@ class FetchCompanyHeadcountJob implements ShouldQueue
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
 
     public int $tries = 3;
+
     public array $backoff = [60, 300, 900]; // 1min, 5min, 15min
 
     public function __construct(
@@ -34,13 +35,13 @@ class FetchCompanyHeadcountJob implements ShouldQueue
         ]);
 
         try {
-            if (!$this->company->linkedin_url) {
+            if (! $this->company->linkedin_url) {
                 throw new \RuntimeException('Company has no LinkedIn URL');
             }
 
             $result = $linkedInService->fetchHeadcount($this->company->linkedin_url);
 
-            if (!$result['success']) {
+            if (! $result['success']) {
                 throw new \RuntimeException($result['error'] ?? 'Unknown error');
             }
 
@@ -58,7 +59,7 @@ class FetchCompanyHeadcountJob implements ShouldQueue
                 ->first();
 
             $snapshotCreated = false;
-            if (!$lastSnapshot || $lastSnapshot->headcount !== $headcount) {
+            if (! $lastSnapshot || $lastSnapshot->headcount !== $headcount) {
                 HeadcountSnapshot::create([
                     'company_id' => $this->company->id,
                     'headcount' => $headcount,

--- a/app/Jobs/FetchNewsMentionsJob.php
+++ b/app/Jobs/FetchNewsMentionsJob.php
@@ -18,6 +18,7 @@ class FetchNewsMentionsJob implements ShouldQueue
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
 
     public int $tries = 3;
+
     public array $backoff = [60, 300, 900]; // 1min, 5min, 15min
 
     public function __construct(
@@ -36,7 +37,7 @@ class FetchNewsMentionsJob implements ShouldQueue
         try {
             $result = $newsSearchService->searchCompanyNews($this->company);
 
-            if (!$result['success']) {
+            if (! $result['success']) {
                 throw new \RuntimeException($result['error'] ?? 'Unknown error');
             }
 
@@ -46,9 +47,10 @@ class FetchNewsMentionsJob implements ShouldQueue
 
             foreach ($articles as $article) {
                 // Validate URL before storing
-                if (!filter_var($article['url'], FILTER_VALIDATE_URL)) {
+                if (! filter_var($article['url'], FILTER_VALIDATE_URL)) {
                     Log::warning("Invalid URL skipped: {$article['url']}");
                     $skipped++;
+
                     continue;
                 }
 

--- a/app/Models/Company.php
+++ b/app/Models/Company.php
@@ -11,6 +11,7 @@ use Illuminate\Database\Eloquent\Relations\HasOne;
 class Company extends Model
 {
     use HasFactory;
+
     public const CATEGORIES = [
         'ai_ml' => 'AI/ML',
         'fintech' => 'Fintech',

--- a/app/Models/Investor.php
+++ b/app/Models/Investor.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 class Investor extends Model
 {
     use HasFactory;
+
     protected $fillable = [
         'name',
         'slug',
@@ -29,7 +30,7 @@ class Investor extends Model
 
     public function getTypeLabelAttribute(): string
     {
-        return match($this->type) {
+        return match ($this->type) {
             'vc' => 'Venture Capital',
             'angel' => 'Angel Investor',
             'corporate' => 'Corporate VC',

--- a/app/Models/SavedSearch.php
+++ b/app/Models/SavedSearch.php
@@ -33,13 +33,21 @@ class SavedSearch extends Model
      */
     public function getDisplayNameAttribute(): string
     {
-        if ($this->name) return $this->name;
+        if ($this->name) {
+            return $this->name;
+        }
 
         $parts = [];
-        if ($this->query) $parts[] = '"' . $this->query . '"';
+        if ($this->query) {
+            $parts[] = '"'.$this->query.'"';
+        }
         if ($filters = $this->filters_json) {
-            if (!empty($filters['category'])) $parts[] = $filters['category'];
-            if (!empty($filters['country'])) $parts[] = $filters['country'];
+            if (! empty($filters['category'])) {
+                $parts[] = $filters['category'];
+            }
+            if (! empty($filters['country'])) {
+                $parts[] = $filters['country'];
+            }
         }
 
         return $parts ? implode(' · ', $parts) : 'All companies';
@@ -51,12 +59,17 @@ class SavedSearch extends Model
     public function getSearchUrlAttribute(): string
     {
         $params = [];
-        if ($this->query) $params['search'] = $this->query;
+        if ($this->query) {
+            $params['search'] = $this->query;
+        }
         if ($filters = $this->filters_json) {
             foreach (['category', 'country', 'funded_recent', 'funded_after', 'funded_before'] as $key) {
-                if (!empty($filters[$key])) $params[$key] = $filters[$key];
+                if (! empty($filters[$key])) {
+                    $params[$key] = $filters[$key];
+                }
             }
         }
+
         return route('companies.index', $params);
     }
 }

--- a/app/Models/ScheduledTaskExecution.php
+++ b/app/Models/ScheduledTaskExecution.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 class ScheduledTaskExecution extends Model
 {
     use HasFactory;
+
     protected $fillable = [
         'task_type',
         'company_id',

--- a/app/Services/BulkImport/BaseBulkImporter.php
+++ b/app/Services/BulkImport/BaseBulkImporter.php
@@ -10,9 +10,13 @@ use Illuminate\Support\Str;
 abstract class BaseBulkImporter
 {
     protected CompanyImport $importLog;
+
     protected int $created = 0;
+
     protected int $updated = 0;
+
     protected int $skipped = 0;
+
     protected int $processed = 0;
 
     abstract public function source(): string;
@@ -64,6 +68,7 @@ abstract class BaseBulkImporter
 
         if (empty($name)) {
             $this->skipped++;
+
             return;
         }
 
@@ -72,14 +77,14 @@ abstract class BaseBulkImporter
         if ($domain) {
             $existing = Company::where('website', 'LIKE', "%{$domain}%")->first();
         }
-        if (!$existing) {
+        if (! $existing) {
             $existing = Company::where('name', $name)->first();
         }
 
         $slug = $data['slug'] ?? Str::slug($name);
         // Ensure unique slug
-        if (!$existing && Company::where('slug', $slug)->exists()) {
-            $slug = $slug . '-' . Str::random(4);
+        if (! $existing && Company::where('slug', $slug)->exists()) {
+            $slug = $slug.'-'.Str::random(4);
         }
 
         $attributes = array_filter([
@@ -97,18 +102,20 @@ abstract class BaseBulkImporter
             'closed_at' => $data['closed_at'] ?? null,
             'acquired_by' => $data['acquired_by'] ?? null,
             'import_source' => $this->source(),
-        ], fn($v) => $v !== null);
+        ], fn ($v) => $v !== null);
 
         if ($existing) {
             // Only update null fields — don't overwrite existing data
             $updates = [];
             foreach ($attributes as $key => $value) {
-                if ($key === 'slug' || $key === 'name') continue;
-                if (empty($existing->$key) && !empty($value)) {
+                if ($key === 'slug' || $key === 'name') {
+                    continue;
+                }
+                if (empty($existing->$key) && ! empty($value)) {
                     $updates[$key] = $value;
                 }
             }
-            if (!empty($updates)) {
+            if (! empty($updates)) {
                 $existing->update($updates);
                 $this->updated++;
             } else {
@@ -122,9 +129,14 @@ abstract class BaseBulkImporter
 
     protected function extractDomain(?string $url): ?string
     {
-        if (!$url) return null;
+        if (! $url) {
+            return null;
+        }
         $host = parse_url($url, PHP_URL_HOST);
-        if (!$host) return null;
+        if (! $host) {
+            return null;
+        }
+
         return preg_replace('/^www\./', '', strtolower($host));
     }
 

--- a/app/Services/BulkImport/CompaniesHouseCsvImporter.php
+++ b/app/Services/BulkImport/CompaniesHouseCsvImporter.php
@@ -41,30 +41,30 @@ class CompaniesHouseCsvImporter extends BaseBulkImporter
         $minIncorporationYear = $options['min_year'] ?? 2015;
         $resumeOffset = $options['resume_from'] ?? 0;
 
-        if (!$filePath) {
+        if (! $filePath) {
             $filePath = $this->downloadCsv();
         }
 
-        if (!file_exists($filePath)) {
+        if (! file_exists($filePath)) {
             throw new \RuntimeException("CSV file not found: {$filePath}");
         }
 
-        Log::info("Companies House CSV import starting", [
+        Log::info('Companies House CSV import starting', [
             'file' => $filePath,
             'tech_only' => $techOnly,
             'min_year' => $minIncorporationYear,
         ]);
 
         $handle = fopen($filePath, 'r');
-        if (!$handle) {
+        if (! $handle) {
             throw new \RuntimeException("Cannot open CSV: {$filePath}");
         }
 
         // Read and normalize header
         $header = fgetcsv($handle);
-        if (!$header) {
+        if (! $header) {
             fclose($handle);
-            throw new \RuntimeException("Empty CSV file");
+            throw new \RuntimeException('Empty CSV file');
         }
 
         // Companies House headers use spaces and dots
@@ -77,28 +77,38 @@ class CompaniesHouseCsvImporter extends BaseBulkImporter
         while (($row = fgetcsv($handle)) !== false) {
             $line++;
 
-            if ($line <= $resumeOffset) continue;
+            if ($line <= $resumeOffset) {
+                continue;
+            }
 
-            if (count($row) !== count($header)) continue;
+            if (count($row) !== count($header)) {
+                continue;
+            }
 
             $data = @array_combine($header, $row);
-            if (!$data) continue;
+            if (! $data) {
+                continue;
+            }
 
             // Filter by incorporation date
             $incDate = $data['incorporationdate'] ?? '';
             if ($incDate && $minIncorporationYear) {
                 $year = (int) substr($incDate, 6, 4); // DD/MM/YYYY format
-                if (!$year) {
+                if (! $year) {
                     $year = (int) substr($incDate, 0, 4); // YYYY-MM-DD format
                 }
-                if ($year > 0 && $year < $minIncorporationYear) continue;
+                if ($year > 0 && $year < $minIncorporationYear) {
+                    continue;
+                }
             }
 
             // Filter by SIC code if tech_only
             if ($techOnly) {
                 $sicCodes = $this->extractSicCodes($data);
                 $category = $this->categorizeBySic($sicCodes);
-                if (!$category) continue;
+                if (! $category) {
+                    continue;
+                }
             }
 
             $this->importRow($data, $category ?? null);
@@ -114,13 +124,15 @@ class CompaniesHouseCsvImporter extends BaseBulkImporter
         }
 
         fclose($handle);
-        Log::info("Companies House CSV import complete", $this->getStats());
+        Log::info('Companies House CSV import complete', $this->getStats());
     }
 
     private function importRow(array $data, ?string $category): void
     {
         $name = $data['companyname'] ?? '';
-        if (!$name || !trim($name)) return;
+        if (! $name || ! trim($name)) {
+            return;
+        }
 
         // Clean ALL CAPS names
         if ($name === strtoupper($name) && strlen($name) > 3) {
@@ -167,6 +179,7 @@ class CompaniesHouseCsvImporter extends BaseBulkImporter
                 }
             }
         }
+
         return $codes;
     }
 
@@ -178,6 +191,7 @@ class CompaniesHouseCsvImporter extends BaseBulkImporter
                 return self::TECH_SIC_PREFIXES[$prefix];
             }
         }
+
         return null;
     }
 
@@ -210,7 +224,7 @@ class CompaniesHouseCsvImporter extends BaseBulkImporter
         ];
 
         $storageDir = storage_path('app/imports/companies-house');
-        if (!is_dir($storageDir)) {
+        if (! is_dir($storageDir)) {
             mkdir($storageDir, 0755, true);
         }
 
@@ -222,32 +236,35 @@ class CompaniesHouseCsvImporter extends BaseBulkImporter
             // If CSV already extracted, use it
             if (file_exists($csvPath)) {
                 Log::info("Using existing Companies House CSV: {$csvPath}");
+
                 return $csvPath;
             }
 
             // Check for any existing CSV
             $existingCsvs = glob("{$storageDir}/*.csv");
-            if (!empty($existingCsvs)) {
+            if (! empty($existingCsvs)) {
                 $latest = end($existingCsvs);
                 Log::info("Using existing Companies House CSV: {$latest}");
+
                 return $latest;
             }
 
             Log::info("Downloading Companies House data from: {$url}");
-            Log::info("This is ~500MB and will take a while...");
+            Log::info('This is ~500MB and will take a while...');
 
             // Download with curl for progress and resume support
             $exitCode = 0;
             $output = [];
-            exec("curl -L -f -o " . escapeshellarg($zipPath) . " " . escapeshellarg($url) . " 2>&1", $output, $exitCode);
+            exec('curl -L -f -o '.escapeshellarg($zipPath).' '.escapeshellarg($url).' 2>&1', $output, $exitCode);
 
             if ($exitCode !== 0) {
                 Log::warning("Failed to download from {$url}");
+
                 continue;
             }
 
             // Extract ZIP
-            $zip = new \ZipArchive();
+            $zip = new \ZipArchive;
             if ($zip->open($zipPath) === true) {
                 $zip->extractTo($storageDir);
                 $zip->close();
@@ -255,16 +272,16 @@ class CompaniesHouseCsvImporter extends BaseBulkImporter
 
                 // Find the extracted CSV
                 $csvFiles = glob("{$storageDir}/*.csv");
-                if (!empty($csvFiles)) {
+                if (! empty($csvFiles)) {
                     return $csvFiles[0];
                 }
             }
         }
 
         throw new \RuntimeException(
-            "Could not download Companies House data. " .
-            "Please download manually from https://download.companieshouse.gov.uk/en_output.html " .
-            "and pass --file=/path/to/csv"
+            'Could not download Companies House data. '.
+            'Please download manually from https://download.companieshouse.gov.uk/en_output.html '.
+            'and pass --file=/path/to/csv'
         );
     }
 }

--- a/app/Services/BulkImport/CrunchbaseCsvImporter.php
+++ b/app/Services/BulkImport/CrunchbaseCsvImporter.php
@@ -17,20 +17,20 @@ class CrunchbaseCsvImporter extends BaseBulkImporter
     {
         $this->filePath = $options['file'] ?? '';
 
-        if (!file_exists($this->filePath)) {
+        if (! file_exists($this->filePath)) {
             throw new \RuntimeException("CSV file not found: {$this->filePath}");
         }
 
         $handle = fopen($this->filePath, 'r');
-        if (!$handle) {
+        if (! $handle) {
             throw new \RuntimeException("Cannot open CSV: {$this->filePath}");
         }
 
         // Read header
         $header = fgetcsv($handle);
-        if (!$header) {
+        if (! $header) {
             fclose($handle);
-            throw new \RuntimeException("Empty CSV file");
+            throw new \RuntimeException('Empty CSV file');
         }
 
         $header = array_map('strtolower', array_map('trim', $header));
@@ -42,10 +42,14 @@ class CrunchbaseCsvImporter extends BaseBulkImporter
         while (($row = fgetcsv($handle)) !== false) {
             $line++;
 
-            if ($line <= $resumeOffset) continue;
+            if ($line <= $resumeOffset) {
+                continue;
+            }
 
             $data = @array_combine($header, $row);
-            if (!$data) continue;
+            if (! $data) {
+                continue;
+            }
 
             $this->importRow($data);
 
@@ -66,7 +70,9 @@ class CrunchbaseCsvImporter extends BaseBulkImporter
     private function importRow(array $row): void
     {
         $name = $row['name'] ?? ($row['organization_name'] ?? null);
-        if (!$name || !trim($name)) return;
+        if (! $name || ! trim($name)) {
+            return;
+        }
 
         $status = $this->mapStatus($row['status'] ?? ($row['operating_status'] ?? 'operating'));
 
@@ -77,9 +83,9 @@ class CrunchbaseCsvImporter extends BaseBulkImporter
         }
 
         $foundedDate = null;
-        if (!empty($row['founded_on'])) {
+        if (! empty($row['founded_on'])) {
             $foundedDate = $row['founded_on'];
-        } elseif (!empty($row['founded_date'])) {
+        } elseif (! empty($row['founded_date'])) {
             $foundedDate = $row['founded_date'];
         }
 
@@ -114,7 +120,9 @@ class CrunchbaseCsvImporter extends BaseBulkImporter
             'c_10001_max' => 15000,
         ];
 
-        if (isset($map[$range])) return $map[$range];
+        if (isset($map[$range])) {
+            return $map[$range];
+        }
 
         // Try parsing "N-M" format
         if (preg_match('/(\d+)\s*[-–]\s*(\d+)/', $range, $m)) {

--- a/app/Services/BulkImport/EdgarBulkImporter.php
+++ b/app/Services/BulkImport/EdgarBulkImporter.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Facades\Log;
 class EdgarBulkImporter extends BaseBulkImporter
 {
     private const SEARCH_INDEX_URL = 'https://efts.sec.gov/LATEST/search-index';
+
     private const PER_PAGE = 100;
 
     public function source(): string
@@ -38,7 +39,7 @@ class EdgarBulkImporter extends BaseBulkImporter
                 'size' => self::PER_PAGE,
             ]);
 
-            if (!$response->successful()) {
+            if (! $response->successful()) {
                 Log::warning("EDGAR API returned HTTP {$response->status()} at offset {$offset}");
                 break;
             }
@@ -46,7 +47,9 @@ class EdgarBulkImporter extends BaseBulkImporter
             $data = $response->json();
             $hits = $data['hits']['hits'] ?? [];
 
-            if (empty($hits)) break;
+            if (empty($hits)) {
+                break;
+            }
 
             foreach ($hits as $hit) {
                 $this->importFiling($hit);
@@ -64,7 +67,9 @@ class EdgarBulkImporter extends BaseBulkImporter
 
             Log::info("EDGAR: offset {$offset}/{$total}, processed: {$this->processed}, created: {$this->created}");
 
-            if ($offset >= $total) break;
+            if ($offset >= $total) {
+                break;
+            }
 
             $this->rateLimitSleep(1.0); // SEC requires polite crawling
         }
@@ -77,7 +82,9 @@ class EdgarBulkImporter extends BaseBulkImporter
         $source = $hit['_source'] ?? [];
 
         $displayNames = $source['display_names'] ?? [];
-        if (empty($displayNames)) return;
+        if (empty($displayNames)) {
+            return;
+        }
 
         // Each filing can have multiple entities; import each
         $bizLocations = $source['biz_locations'] ?? [];
@@ -93,7 +100,9 @@ class EdgarBulkImporter extends BaseBulkImporter
             $entityName = preg_replace('/\s*\([A-Z]+\)\s*/', ' ', $entityName);
             $entityName = trim($entityName);
 
-            if (!$entityName) continue;
+            if (! $entityName) {
+                continue;
+            }
 
             // Skip clearly non-startup entities (funds, trusts, LPs, etc.)
             $skipPatterns = [
@@ -116,6 +125,7 @@ class EdgarBulkImporter extends BaseBulkImporter
             if ($skip) {
                 $this->skipped++;
                 $this->processed++;
+
                 continue;
             }
 
@@ -142,6 +152,7 @@ class EdgarBulkImporter extends BaseBulkImporter
     {
         // Remove common suffixes like ", Inc.", ", Corp.", etc.
         $name = preg_replace('/,?\s*(Inc\.?|Corp\.?|Co\.?|Ltd\.?)$/i', '', $name);
+
         return trim($name);
     }
 }

--- a/app/Services/BulkImport/GitHubOrgImporter.php
+++ b/app/Services/BulkImport/GitHubOrgImporter.php
@@ -24,7 +24,9 @@ class GitHubOrgImporter extends BaseBulkImporter
     ];
 
     private ?string $token;
+
     private int $requestCount = 0;
+
     private float $windowStart;
 
     public function source(): string
@@ -37,14 +39,14 @@ class GitHubOrgImporter extends BaseBulkImporter
         $this->token = env('GITHUB_TOKEN') ?: null;
         $this->windowStart = microtime(true);
 
-        Log::info("GitHub org import starting", ['has_token' => (bool) $this->token]);
+        Log::info('GitHub org import starting', ['has_token' => (bool) $this->token]);
 
         foreach (self::SEARCH_QUERIES as $query) {
             Log::info("Searching GitHub orgs: {$query}");
             $this->searchAndImport($query, $options['max_pages'] ?? 10);
         }
 
-        Log::info("GitHub org import complete", $this->getStats());
+        Log::info('GitHub org import complete', $this->getStats());
     }
 
     private function searchAndImport(string $query, int $maxPages): void
@@ -61,11 +63,12 @@ class GitHubOrgImporter extends BaseBulkImporter
                 'page' => $page,
             ]);
 
-            if (!$response || !$response->successful()) {
+            if (! $response || ! $response->successful()) {
                 if ($response && $response->status() === 403) {
-                    Log::warning("GitHub: Rate limited, waiting 60s");
+                    Log::warning('GitHub: Rate limited, waiting 60s');
                     sleep(60);
                     $page--; // Retry
+
                     continue;
                 }
                 Log::warning("GitHub: Search failed for query: {$query}");
@@ -75,18 +78,24 @@ class GitHubOrgImporter extends BaseBulkImporter
             $data = $response->json();
             $items = $data['items'] ?? [];
 
-            if (empty($items)) break;
+            if (empty($items)) {
+                break;
+            }
 
             foreach ($items as $item) {
                 $login = $item['login'] ?? '';
-                if (!$login) continue;
+                if (! $login) {
+                    continue;
+                }
 
                 $this->importOrg($login);
             }
 
             // Check if there are more results
             $totalCount = $data['total_count'] ?? 0;
-            if ($page * 100 >= $totalCount) break;
+            if ($page * 100 >= $totalCount) {
+                break;
+            }
         }
     }
 
@@ -96,7 +105,9 @@ class GitHubOrgImporter extends BaseBulkImporter
 
         $response = $this->githubGet("/orgs/{$login}");
 
-        if (!$response || !$response->successful()) return;
+        if (! $response || ! $response->successful()) {
+            return;
+        }
 
         $org = $response->json();
 
@@ -109,9 +120,10 @@ class GitHubOrgImporter extends BaseBulkImporter
         $createdAt = $org['created_at'] ?? '';
 
         // Skip orgs without a name or website (less likely to be companies)
-        if (!$name || strlen($name) < 2) {
+        if (! $name || strlen($name) < 2) {
             $this->skipped++;
             $this->processed++;
+
             return;
         }
 
@@ -120,8 +132,8 @@ class GitHubOrgImporter extends BaseBulkImporter
 
         // Parse website
         $website = $blog;
-        if ($website && !str_starts_with($website, 'http')) {
-            $website = 'https://' . $website;
+        if ($website && ! str_starts_with($website, 'http')) {
+            $website = 'https://'.$website;
         }
 
         // Parse founded date from created_at
@@ -154,9 +166,10 @@ class GitHubOrgImporter extends BaseBulkImporter
         }
 
         try {
-            return $request->get(self::GITHUB_API . $path, $query);
+            return $request->get(self::GITHUB_API.$path, $query);
         } catch (\Exception $e) {
             Log::warning("GitHub API error: {$e->getMessage()}");
+
             return null;
         }
     }
@@ -182,7 +195,9 @@ class GitHubOrgImporter extends BaseBulkImporter
 
     private function parseLocation(?string $location): array
     {
-        if (!$location) return [];
+        if (! $location) {
+            return [];
+        }
 
         $cityCountryMap = [
             'san francisco' => ['city' => 'San Francisco', 'country' => 'US'],
@@ -199,7 +214,9 @@ class GitHubOrgImporter extends BaseBulkImporter
 
         $lower = strtolower($location);
         foreach ($cityCountryMap as $key => $val) {
-            if (str_contains($lower, $key)) return $val;
+            if (str_contains($lower, $key)) {
+                return $val;
+            }
         }
 
         // Try to parse "City, Country" or "City, State, Country"

--- a/app/Services/BulkImport/GitHubTrendingImporter.php
+++ b/app/Services/BulkImport/GitHubTrendingImporter.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Facades\Log;
 class GitHubTrendingImporter extends BaseBulkImporter
 {
     private const TRENDING_URL = 'https://github.com/trending';
+
     private const API_URL = 'https://api.github.com';
 
     public function source(): string
@@ -17,7 +18,7 @@ class GitHubTrendingImporter extends BaseBulkImporter
 
     public function import(array $options = []): void
     {
-        Log::info("GitHub Trending import starting");
+        Log::info('GitHub Trending import starting');
 
         // Scrape trending repos for different time ranges
         $ranges = ['daily', 'weekly', 'monthly'];
@@ -31,7 +32,7 @@ class GitHubTrendingImporter extends BaseBulkImporter
             $this->rateLimitSleep(1.0);
         }
 
-        Log::info("GitHub Trending: found " . count($repos) . " unique repos");
+        Log::info('GitHub Trending: found '.count($repos).' unique repos');
 
         foreach (array_keys($repos) as $repoPath) {
             $this->processRepo($repoPath);
@@ -52,8 +53,9 @@ class GitHubTrendingImporter extends BaseBulkImporter
             'User-Agent' => 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)',
         ])->timeout(15)->get(self::TRENDING_URL, ['since' => $since]);
 
-        if (!$response->successful()) {
+        if (! $response->successful()) {
             Log::warning("GitHub trending page returned HTTP {$response->status()} for {$since}");
+
             return [];
         }
 
@@ -63,7 +65,7 @@ class GitHubTrendingImporter extends BaseBulkImporter
         preg_match_all('/class="h3 lh-condensed".*?href="([^"]+)"/s', $html, $matches);
 
         $repos = [];
-        if (!empty($matches[1])) {
+        if (! empty($matches[1])) {
             foreach ($matches[1] as $path) {
                 $path = ltrim($path, '/');
                 if (substr_count($path, '/') === 1) {
@@ -80,11 +82,12 @@ class GitHubTrendingImporter extends BaseBulkImporter
         $response = Http::withHeaders([
             'User-Agent' => 'StartupGraph/1.0 research@startupgraph.com',
             'Accept' => 'application/vnd.github.v3+json',
-        ])->timeout(15)->get(self::API_URL . "/repos/{$repoPath}");
+        ])->timeout(15)->get(self::API_URL."/repos/{$repoPath}");
 
-        if (!$response->successful()) {
+        if (! $response->successful()) {
             $this->skipped++;
             $this->processed++;
+
             return;
         }
 
@@ -94,6 +97,7 @@ class GitHubTrendingImporter extends BaseBulkImporter
         if ($repo['fork'] ?? false) {
             $this->skipped++;
             $this->processed++;
+
             return;
         }
 
@@ -110,7 +114,7 @@ class GitHubTrendingImporter extends BaseBulkImporter
             $orgResponse = Http::withHeaders([
                 'User-Agent' => 'StartupGraph/1.0',
                 'Accept' => 'application/vnd.github.v3+json',
-            ])->timeout(10)->get(self::API_URL . "/orgs/{$name}");
+            ])->timeout(10)->get(self::API_URL."/orgs/{$name}");
 
             if ($orgResponse->successful()) {
                 $orgData = $orgResponse->json();
@@ -123,9 +127,10 @@ class GitHubTrendingImporter extends BaseBulkImporter
             $name = $repo['name'] ?? null;
         }
 
-        if (!$name) {
+        if (! $name) {
             $this->skipped++;
             $this->processed++;
+
             return;
         }
 
@@ -135,6 +140,7 @@ class GitHubTrendingImporter extends BaseBulkImporter
             if (preg_match($pattern, $name)) {
                 $this->skipped++;
                 $this->processed++;
+
                 return;
             }
         }

--- a/app/Services/BulkImport/OpenCorporatesBulkImporter.php
+++ b/app/Services/BulkImport/OpenCorporatesBulkImporter.php
@@ -25,6 +25,7 @@ class OpenCorporatesBulkImporter extends BaseBulkImporter
 
     // Free tier: 500 requests/day with API key, 50 without
     private const RATE_LIMIT_SECONDS = 8.0; // ~450 requests/hour, well within limits
+
     private const PER_PAGE = 30;
 
     public function source(): string
@@ -38,15 +39,16 @@ class OpenCorporatesBulkImporter extends BaseBulkImporter
         $maxPages = $options['max_pages'] ?? 5; // Conservative default for free tier
         $createdSince = $options['created_since'] ?? '2020-01-01';
 
-        Log::info("OpenCorporates import starting", [
-            'has_token' => !empty($apiToken),
+        Log::info('OpenCorporates import starting', [
+            'has_token' => ! empty($apiToken),
             'max_pages' => $maxPages,
             'created_since' => $createdSince,
         ]);
 
         if (empty($apiToken)) {
-            Log::warning("OpenCorporates: No API token configured. Set OPENCORPORATES_API_TOKEN in .env");
-            Log::warning("OpenCorporates: Get a free API key at https://opencorporates.com/users/sign_up");
+            Log::warning('OpenCorporates: No API token configured. Set OPENCORPORATES_API_TOKEN in .env');
+            Log::warning('OpenCorporates: Get a free API key at https://opencorporates.com/users/sign_up');
+
             return;
         }
 
@@ -56,7 +58,7 @@ class OpenCorporatesBulkImporter extends BaseBulkImporter
             }
         }
 
-        Log::info("OpenCorporates import complete", $this->getStats());
+        Log::info('OpenCorporates import complete', $this->getStats());
     }
 
     private function searchAndImport(
@@ -81,19 +83,21 @@ class OpenCorporatesBulkImporter extends BaseBulkImporter
             }
 
             try {
-                $response = Http::timeout(30)->get(self::BASE_URL . '/companies/search', $params);
+                $response = Http::timeout(30)->get(self::BASE_URL.'/companies/search', $params);
 
                 if ($response->status() === 401 || $response->status() === 403) {
-                    Log::warning("OpenCorporates: API token required or invalid. Stopping.");
+                    Log::warning('OpenCorporates: API token required or invalid. Stopping.');
+
                     return;
                 }
 
                 if ($response->status() === 429) {
                     Log::warning("OpenCorporates: Rate limit hit. Stopping search for {$query}/{$jurisdiction}.");
+
                     return;
                 }
 
-                if (!$response->successful()) {
+                if (! $response->successful()) {
                     Log::warning("OpenCorporates: HTTP {$response->status()} for {$query}/{$jurisdiction} page {$page}");
                     break;
                 }
@@ -134,7 +138,9 @@ class OpenCorporatesBulkImporter extends BaseBulkImporter
     private function importCompany(array $company, string $jurisdiction): void
     {
         $name = $company['name'] ?? null;
-        if (!$name) return;
+        if (! $name) {
+            return;
+        }
 
         // Clean up ALL CAPS names common in corporate registries
         if ($name === strtoupper($name) && strlen($name) > 3) {

--- a/app/Services/BulkImport/ProductHuntBulkImporter.php
+++ b/app/Services/BulkImport/ProductHuntBulkImporter.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Facades\Log;
 class ProductHuntBulkImporter extends BaseBulkImporter
 {
     private const GRAPHQL_URL = 'https://api.producthunt.com/v2/api/graphql';
+
     private const PER_PAGE = 20;
 
     public function source(): string
@@ -18,7 +19,7 @@ class ProductHuntBulkImporter extends BaseBulkImporter
     public function import(array $options = []): void
     {
         $token = config('services.producthunt.token');
-        if (!$token) {
+        if (! $token) {
             throw new \RuntimeException('PRODUCT_HUNT_TOKEN not configured. Set it in .env');
         }
 
@@ -26,7 +27,7 @@ class ProductHuntBulkImporter extends BaseBulkImporter
         $maxPages = $options['max_pages'] ?? 500; // Safety limit
         $page = 0;
 
-        Log::info("Product Hunt bulk import starting" . ($cursor ? " from cursor {$cursor}" : ''));
+        Log::info('Product Hunt bulk import starting'.($cursor ? " from cursor {$cursor}" : ''));
 
         while ($page < $maxPages) {
             $query = $this->buildQuery($cursor);
@@ -37,7 +38,7 @@ class ProductHuntBulkImporter extends BaseBulkImporter
                 'Accept' => 'application/json',
             ])->timeout(30)->post(self::GRAPHQL_URL, ['query' => $query]);
 
-            if (!$response->successful()) {
+            if (! $response->successful()) {
                 Log::warning("Product Hunt API returned HTTP {$response->status()}");
                 break;
             }
@@ -45,7 +46,9 @@ class ProductHuntBulkImporter extends BaseBulkImporter
             $data = $response->json();
             $posts = $data['data']['posts']['edges'] ?? [];
 
-            if (empty($posts)) break;
+            if (empty($posts)) {
+                break;
+            }
 
             foreach ($posts as $edge) {
                 $this->importPost($edge['node']);
@@ -65,7 +68,9 @@ class ProductHuntBulkImporter extends BaseBulkImporter
             $page++;
             Log::info("Product Hunt: page {$page}, processed: {$this->processed}, created: {$this->created}");
 
-            if (!$hasNext) break;
+            if (! $hasNext) {
+                break;
+            }
 
             $this->rateLimitSleep(1.0);
         }
@@ -75,7 +80,7 @@ class ProductHuntBulkImporter extends BaseBulkImporter
 
     private function buildQuery(?string $cursor): string
     {
-        $after = $cursor ? ', after: "' . $cursor . '"' : '';
+        $after = $cursor ? ', after: "'.$cursor.'"' : '';
 
         return <<<GRAPHQL
         {
@@ -116,7 +121,9 @@ class ProductHuntBulkImporter extends BaseBulkImporter
         $name = $post['name'] ?? null;
         $website = $post['website'] ?? null;
 
-        if (!$name) return;
+        if (! $name) {
+            return;
+        }
 
         $topics = collect($post['topics']['edges'] ?? [])
             ->pluck('node.name')

--- a/app/Services/BulkImport/WikipediaAcquisitionsImporter.php
+++ b/app/Services/BulkImport/WikipediaAcquisitionsImporter.php
@@ -31,7 +31,7 @@ class WikipediaAcquisitionsImporter extends BaseBulkImporter
 
     public function import(array $options = []): void
     {
-        Log::info("Wikipedia acquisitions import starting");
+        Log::info('Wikipedia acquisitions import starting');
 
         foreach (self::ACQUIRER_PAGES as $acquirer => $page) {
             Log::info("Importing acquisitions by {$acquirer}");
@@ -39,7 +39,7 @@ class WikipediaAcquisitionsImporter extends BaseBulkImporter
             $this->rateLimitSleep(1.0);
         }
 
-        Log::info("Wikipedia acquisitions import complete", $this->getStats());
+        Log::info('Wikipedia acquisitions import complete', $this->getStats());
     }
 
     private function importFromPage(string $acquirer, string $pageTitle): void
@@ -53,8 +53,9 @@ class WikipediaAcquisitionsImporter extends BaseBulkImporter
                 'prop' => 'wikitext',
             ]);
 
-        if (!$response->successful()) {
+        if (! $response->successful()) {
             Log::warning("Wikipedia: Failed to fetch {$pageTitle}");
+
             return;
         }
 
@@ -63,6 +64,7 @@ class WikipediaAcquisitionsImporter extends BaseBulkImporter
 
         if (empty($wikitext)) {
             Log::warning("Wikipedia: Empty wikitext for {$pageTitle}");
+
             return;
         }
 
@@ -79,30 +81,36 @@ class WikipediaAcquisitionsImporter extends BaseBulkImporter
 
         foreach ($rows as $i => $row) {
             // Look for header rows with ! markers
-            if (!$headerFound && preg_match_all('/\n!\s*(.+)/', "\n" . $row, $headerMatches)) {
+            if (! $headerFound && preg_match_all('/\n!\s*(.+)/', "\n".$row, $headerMatches)) {
                 $headers = $headerMatches[1] ?? [];
                 if (count($headers) >= 2) {
-                    $columns = array_map(fn($h) => strtolower($this->cleanWikiText($h)), $headers);
+                    $columns = array_map(fn ($h) => strtolower($this->cleanWikiText($h)), $headers);
                     // Check if this looks like an acquisitions table
                     $hasCompany = $this->findColumn($columns, ['company', 'acquisition', 'name', 'target']);
                     if ($hasCompany !== null) {
                         $headerFound = true;
+
                         continue;
                     }
                 }
             }
 
-            if (!$headerFound) continue;
+            if (! $headerFound) {
+                continue;
+            }
 
             // End of table
             if (str_contains($row, '|}')) {
                 $headerFound = false;
+
                 continue;
             }
 
             // Parse cells
             $cells = $this->extractCells($row);
-            if (count($cells) < 2) continue;
+            if (count($cells) < 2) {
+                continue;
+            }
 
             $nameCol = $this->findColumn($columns, ['company', 'acquisition', 'name', 'target']);
             $dateCol = $this->findColumn($columns, ['date', 'announced', 'completed', 'year']);
@@ -110,8 +118,12 @@ class WikipediaAcquisitionsImporter extends BaseBulkImporter
             $descCol = $this->findColumn($columns, ['description', 'business', 'area', 'notes', 'used for', 'products/services']);
 
             $name = $this->cleanWikiText($cells[$nameCol] ?? '');
-            if (!$name || strlen($name) < 2 || is_numeric($name)) continue;
-            if (str_contains(strtolower($name), 'total') || str_contains($name, '=')) continue;
+            if (! $name || strlen($name) < 2 || is_numeric($name)) {
+                continue;
+            }
+            if (str_contains(strtolower($name), 'total') || str_contains($name, '=')) {
+                continue;
+            }
 
             $date = $dateCol !== null ? $this->cleanWikiText($cells[$dateCol] ?? '') : null;
             $description = $descCol !== null ? $this->cleanWikiText($cells[$descCol] ?? '') : null;
@@ -120,7 +132,7 @@ class WikipediaAcquisitionsImporter extends BaseBulkImporter
             // Build description with price info
             $fullDesc = $description;
             if ($price && $price !== '' && strtolower($price) !== 'n/a' && strtolower($price) !== 'undisclosed') {
-                $fullDesc = ($fullDesc ? $fullDesc . '. ' : '') . "Acquired for {$price}.";
+                $fullDesc = ($fullDesc ? $fullDesc.'. ' : '')."Acquired for {$price}.";
             }
 
             // Parse founded/acquisition date
@@ -128,7 +140,7 @@ class WikipediaAcquisitionsImporter extends BaseBulkImporter
             if ($date) {
                 // Try to extract a year
                 if (preg_match('/(\d{4})/', $date, $m)) {
-                    $foundedDate = $m[1] . '-01-01';
+                    $foundedDate = $m[1].'-01-01';
                 }
             }
 
@@ -147,7 +159,9 @@ class WikipediaAcquisitionsImporter extends BaseBulkImporter
         $lines = explode("\n", $row);
         foreach ($lines as $line) {
             $line = trim($line);
-            if ($line === '' || $line === '|-' || $line === '|}') continue;
+            if ($line === '' || $line === '|-' || $line === '|}') {
+                continue;
+            }
             if (str_starts_with($line, '|')) {
                 // Handle multiple cells on one line separated by ||
                 $parts = explode('||', substr($line, 1));
@@ -156,6 +170,7 @@ class WikipediaAcquisitionsImporter extends BaseBulkImporter
                 }
             }
         }
+
         return $cells;
     }
 
@@ -168,6 +183,7 @@ class WikipediaAcquisitionsImporter extends BaseBulkImporter
                 }
             }
         }
+
         return null;
     }
 
@@ -179,6 +195,7 @@ class WikipediaAcquisitionsImporter extends BaseBulkImporter
         $text = preg_replace('/<ref[^>]*>.*?<\/ref>/s', '', $text);
         $text = preg_replace('/<ref[^>]*\/?>/s', '', $text);
         $text = trim(preg_replace('/\s+/', ' ', $text));
+
         return $text;
     }
 }

--- a/app/Services/BulkImport/WikipediaCategoryImporter.php
+++ b/app/Services/BulkImport/WikipediaCategoryImporter.php
@@ -33,14 +33,14 @@ class WikipediaCategoryImporter extends BaseBulkImporter
 
     public function import(array $options = []): void
     {
-        Log::info("Wikipedia category companies import starting");
+        Log::info('Wikipedia category companies import starting');
 
         foreach (self::CATEGORIES as $category => $status) {
             Log::info("Importing from {$category}");
             $this->importCategory($category, $status);
         }
 
-        Log::info("Wikipedia category companies import complete", $this->getStats());
+        Log::info('Wikipedia category companies import complete', $this->getStats());
     }
 
     private function importCategory(string $category, string $status): void
@@ -75,7 +75,7 @@ class WikipediaCategoryImporter extends BaseBulkImporter
                 ->withUserAgent('StartupGraph/1.0 (https://startupgraph.com)')
                 ->get(self::WIKIPEDIA_API, $params);
 
-            if (!$response->successful()) {
+            if (! $response->successful()) {
                 Log::warning("Wikipedia: Failed to fetch category {$category}");
                 break;
             }
@@ -85,7 +85,7 @@ class WikipediaCategoryImporter extends BaseBulkImporter
             $continue = $data['continue']['cmcontinue'] ?? null;
 
             // Batch fetch extracts
-            $titles = array_map(fn($m) => $m['title'], $members);
+            $titles = array_map(fn ($m) => $m['title'], $members);
             $chunks = array_chunk($titles, 50);
 
             foreach ($chunks as $chunk) {
@@ -110,7 +110,7 @@ class WikipediaCategoryImporter extends BaseBulkImporter
                 'format' => 'json',
             ]);
 
-        if (!$response->successful()) {
+        if (! $response->successful()) {
             foreach ($titles as $title) {
                 $this->upsertCompany([
                     'name' => $title,
@@ -119,6 +119,7 @@ class WikipediaCategoryImporter extends BaseBulkImporter
                     'country' => $country,
                 ]);
             }
+
             return;
         }
 
@@ -128,11 +129,15 @@ class WikipediaCategoryImporter extends BaseBulkImporter
             $title = $page['title'] ?? '';
             $extract = $page['extract'] ?? '';
 
-            if (!$title || str_starts_with($title, 'Category:')) continue;
+            if (! $title || str_starts_with($title, 'Category:')) {
+                continue;
+            }
 
             // Skip disambiguation and list pages
             if (str_contains(strtolower($extract), 'may refer to') ||
-                str_contains(strtolower($title), 'list of')) continue;
+                str_contains(strtolower($title), 'list of')) {
+                continue;
+            }
 
             $description = $extract ? substr(trim($extract), 0, 500) : null;
 

--- a/app/Services/BulkImport/WikipediaDefunctImporter.php
+++ b/app/Services/BulkImport/WikipediaDefunctImporter.php
@@ -21,14 +21,14 @@ class WikipediaDefunctImporter extends BaseBulkImporter
 
     public function import(array $options = []): void
     {
-        Log::info("Wikipedia defunct companies import starting");
+        Log::info('Wikipedia defunct companies import starting');
 
         foreach (self::CATEGORIES as $category) {
             Log::info("Importing from {$category}");
             $this->importCategory($category, 'closed');
         }
 
-        Log::info("Wikipedia defunct companies import complete", $this->getStats());
+        Log::info('Wikipedia defunct companies import complete', $this->getStats());
     }
 
     private function importCategory(string $category, string $status): void
@@ -54,7 +54,7 @@ class WikipediaDefunctImporter extends BaseBulkImporter
                 ->withUserAgent('StartupGraph/1.0 (https://startupgraph.com)')
                 ->get(self::WIKIPEDIA_API, $params);
 
-            if (!$response->successful()) {
+            if (! $response->successful()) {
                 Log::warning("Wikipedia: Failed to fetch category {$category}");
                 break;
             }
@@ -64,7 +64,7 @@ class WikipediaDefunctImporter extends BaseBulkImporter
             $continue = $data['continue']['cmcontinue'] ?? null;
 
             // Batch fetch extracts for up to 50 titles at a time
-            $titles = array_map(fn($m) => $m['title'], $members);
+            $titles = array_map(fn ($m) => $m['title'], $members);
             $chunks = array_chunk($titles, 50);
 
             foreach ($chunks as $chunk) {
@@ -89,7 +89,7 @@ class WikipediaDefunctImporter extends BaseBulkImporter
                 'format' => 'json',
             ]);
 
-        if (!$response->successful()) {
+        if (! $response->successful()) {
             // Fall back to just importing names
             foreach ($titles as $title) {
                 $this->upsertCompany([
@@ -98,6 +98,7 @@ class WikipediaDefunctImporter extends BaseBulkImporter
                     'country' => 'US',
                 ]);
             }
+
             return;
         }
 
@@ -107,11 +108,15 @@ class WikipediaDefunctImporter extends BaseBulkImporter
             $title = $page['title'] ?? '';
             $extract = $page['extract'] ?? '';
 
-            if (!$title || str_starts_with($title, 'Category:')) continue;
+            if (! $title || str_starts_with($title, 'Category:')) {
+                continue;
+            }
 
             // Skip disambiguation pages and lists
             if (str_contains(strtolower($extract), 'may refer to') ||
-                str_contains(strtolower($title), 'list of')) continue;
+                str_contains(strtolower($title), 'list of')) {
+                continue;
+            }
 
             $description = $extract ? substr(trim($extract), 0, 500) : null;
 

--- a/app/Services/BulkImport/WikipediaUnicornImporter.php
+++ b/app/Services/BulkImport/WikipediaUnicornImporter.php
@@ -20,13 +20,13 @@ class WikipediaUnicornImporter extends BaseBulkImporter
 
     public function import(array $options = []): void
     {
-        Log::info("Wikipedia unicorn import starting");
+        Log::info('Wikipedia unicorn import starting');
 
         foreach (self::PAGES as $page) {
             $this->importFromPage($page);
         }
 
-        Log::info("Wikipedia unicorn import complete", $this->getStats());
+        Log::info('Wikipedia unicorn import complete', $this->getStats());
     }
 
     private function importFromPage(string $pageTitle): void
@@ -39,8 +39,9 @@ class WikipediaUnicornImporter extends BaseBulkImporter
             'prop' => 'wikitext',
         ]);
 
-        if (!$response->successful()) {
+        if (! $response->successful()) {
             Log::warning("Wikipedia: Failed to fetch {$pageTitle}");
+
             return;
         }
 
@@ -49,6 +50,7 @@ class WikipediaUnicornImporter extends BaseBulkImporter
 
         if (empty($wikitext)) {
             Log::warning("Wikipedia: Empty wikitext for {$pageTitle}");
+
             return;
         }
 
@@ -68,16 +70,17 @@ class WikipediaUnicornImporter extends BaseBulkImporter
             // Headers use ! prefix on each line
             if (str_contains($row, '!Company') && str_contains($row, '!Industry')) {
                 // Parse header cells: each starts with ! on its own line
-                preg_match_all('/\n!\s*(.+)/', "\n" . $row, $headerMatches);
-                $columns = array_map(fn($h) => strtolower($this->cleanWikiText($h)), $headerMatches[1] ?? []);
+                preg_match_all('/\n!\s*(.+)/', "\n".$row, $headerMatches);
+                $columns = array_map(fn ($h) => strtolower($this->cleanWikiText($h)), $headerMatches[1] ?? []);
                 $headerIdx = $i;
-                Log::info("Wikipedia: Found header at row {$i} with columns: " . implode(', ', $columns));
+                Log::info("Wikipedia: Found header at row {$i} with columns: ".implode(', ', $columns));
                 break;
             }
         }
 
         if ($headerIdx === null || empty($columns)) {
-            Log::warning("Wikipedia: Could not find company table headers");
+            Log::warning('Wikipedia: Could not find company table headers');
+
             return;
         }
 
@@ -87,7 +90,8 @@ class WikipediaUnicornImporter extends BaseBulkImporter
         $industryCol = $this->findColumn($columns, ['industry', 'sector']);
 
         if ($nameCol === null) {
-            Log::warning("Wikipedia: No company column found in: " . implode(', ', $columns));
+            Log::warning('Wikipedia: No company column found in: '.implode(', ', $columns));
+
             return;
         }
 
@@ -96,7 +100,9 @@ class WikipediaUnicornImporter extends BaseBulkImporter
             $row = $rows[$i];
 
             // Stop if we hit end of table or new section
-            if (str_contains($row, '|}')) break;
+            if (str_contains($row, '|}')) {
+                break;
+            }
 
             // Each data cell starts with | on its own line
             // Split by \n| but not \n|- or \n|} or \n||
@@ -104,19 +110,27 @@ class WikipediaUnicornImporter extends BaseBulkImporter
             $lines = explode("\n", $row);
             foreach ($lines as $line) {
                 $line = trim($line);
-                if ($line === '' || $line === '|-' || $line === '|}') continue;
+                if ($line === '' || $line === '|-' || $line === '|}') {
+                    continue;
+                }
                 if (str_starts_with($line, '|')) {
                     $cells[] = substr($line, 1);
                 }
             }
 
-            if (count($cells) < 3) continue;
+            if (count($cells) < 3) {
+                continue;
+            }
 
             $name = $this->cleanWikiText($cells[$nameCol] ?? '');
-            if (!$name || strlen($name) < 2 || is_numeric($name)) continue;
+            if (! $name || strlen($name) < 2 || is_numeric($name)) {
+                continue;
+            }
 
             // Skip non-company entries
-            if (str_contains(strtolower($name), 'total') || str_contains($name, '=')) continue;
+            if (str_contains(strtolower($name), 'total') || str_contains($name, '=')) {
+                continue;
+            }
 
             $country = $countryCol !== null ? $this->cleanWikiText($cells[$countryCol] ?? '') : null;
             // Clean flag template from country: {{flag|United States}} -> United States
@@ -147,6 +161,7 @@ class WikipediaUnicornImporter extends BaseBulkImporter
                 }
             }
         }
+
         return null;
     }
 
@@ -169,7 +184,9 @@ class WikipediaUnicornImporter extends BaseBulkImporter
 
     private function mapCountryName(?string $country): ?string
     {
-        if (!$country) return null;
+        if (! $country) {
+            return null;
+        }
         $country = strtolower(trim($country));
 
         $map = [
@@ -187,7 +204,9 @@ class WikipediaUnicornImporter extends BaseBulkImporter
 
     private function mapIndustry(?string $industry): ?string
     {
-        if (!$industry) return null;
+        if (! $industry) {
+            return null;
+        }
         $industry = strtolower($industry);
 
         $map = [

--- a/app/Services/BulkImport/YCBulkImporter.php
+++ b/app/Services/BulkImport/YCBulkImporter.php
@@ -8,9 +8,13 @@ use Illuminate\Support\Facades\Log;
 class YCBulkImporter extends BaseBulkImporter
 {
     private const BROWSE_URL = 'https://45BWZJ1SGC-dsn.algolia.net/1/indexes/YCCompany_production/browse';
+
     private const QUERY_URL = 'https://45BWZJ1SGC-dsn.algolia.net/1/indexes/YCCompany_production/query';
+
     private const APP_ID = '45BWZJ1SGC';
+
     private const API_KEY = 'ZjA3NWMwMmNhMzEwZmMxOThkZDlkMjFmNDAwNTNjNjdkZjdhNWJkOWRjMThiODQwMjUyZTVkYjA4YjFlMmU2YnJlc3RyaWN0SW5kaWNlcz0lNUIlMjJZQ0NvbXBhbnlfcHJvZHVjdGlvbiUyMiUyQyUyMllDQ29tcGFueV9CeV9MYXVuY2hfRGF0ZV9wcm9kdWN0aW9uJTIyJTVEJnRhZ0ZpbHRlcnM9JTVCJTIyeWNkY19wdWJsaWMlMjIlNUQmYW5hbHl0aWNzVGFncz0lNUIlMjJ5Y2RjJTIyJTVE';
+
     private const HITS_PER_PAGE = 1000;
 
     public function source(): string
@@ -20,12 +24,13 @@ class YCBulkImporter extends BaseBulkImporter
 
     public function import(array $options = []): void
     {
-        Log::info("YC bulk import starting — fetching batches");
+        Log::info('YC bulk import starting — fetching batches');
 
         // First, get all batch facets
         $batches = $this->fetchBatches();
         if (empty($batches)) {
-            Log::warning("YC: no batches found");
+            Log::warning('YC: no batches found');
+
             return;
         }
 
@@ -35,7 +40,7 @@ class YCBulkImporter extends BaseBulkImporter
 
         foreach ($batches as $batch => $count) {
             $batchNum++;
-            if (!$started) {
+            if (! $started) {
                 if ($batch === $resumeFrom) {
                     $started = true;
                 } else {
@@ -43,7 +48,7 @@ class YCBulkImporter extends BaseBulkImporter
                 }
             }
 
-            Log::info("YC: importing batch '{$batch}' ({$count} companies, batch {$batchNum}/" . count($batches) . ")");
+            Log::info("YC: importing batch '{$batch}' ({$count} companies, batch {$batchNum}/".count($batches).')');
 
             $page = 0;
             while (true) {
@@ -58,7 +63,7 @@ class YCBulkImporter extends BaseBulkImporter
                     'facetFilters' => [["batch:{$batch}"]],
                 ]);
 
-                if (!$response->successful()) {
+                if (! $response->successful()) {
                     Log::warning("YC API returned HTTP {$response->status()} for batch '{$batch}' page {$page}");
                     break;
                 }
@@ -66,7 +71,9 @@ class YCBulkImporter extends BaseBulkImporter
                 $data = $response->json();
                 $hits = $data['hits'] ?? [];
 
-                if (empty($hits)) break;
+                if (empty($hits)) {
+                    break;
+                }
 
                 foreach ($hits as $hit) {
                     $this->importHit($hit);
@@ -75,7 +82,9 @@ class YCBulkImporter extends BaseBulkImporter
                 $totalPages = $data['nbPages'] ?? 0;
                 $page++;
 
-                if ($page >= $totalPages) break;
+                if ($page >= $totalPages) {
+                    break;
+                }
 
                 $this->rateLimitSleep(0.3);
             }
@@ -105,7 +114,7 @@ class YCBulkImporter extends BaseBulkImporter
             'facets' => ['batch'],
         ]);
 
-        if (!$response->successful()) {
+        if (! $response->successful()) {
             return [];
         }
 
@@ -115,7 +124,9 @@ class YCBulkImporter extends BaseBulkImporter
     private function importHit(array $hit): void
     {
         $name = $hit['name'] ?? null;
-        if (!$name) return;
+        if (! $name) {
+            return;
+        }
 
         $status = 'operating';
         if (isset($hit['status'])) {
@@ -169,8 +180,10 @@ class YCBulkImporter extends BaseBulkImporter
         // e.g., "W2024" -> 2024-01-01, "S2024" -> 2024-06-01
         if (preg_match('/^([WS])(\d{4})$/', $batch, $m)) {
             $month = $m[1] === 'W' ? '01' : '06';
+
             return "{$m[2]}-{$month}-01";
         }
+
         return null;
     }
 }

--- a/app/Services/DiscoverCompaniesService.php
+++ b/app/Services/DiscoverCompaniesService.php
@@ -6,9 +6,9 @@ use App\Contracts\CompanyDiscoverySource;
 use App\Models\Company;
 use App\Services\Discovery\CrunchbaseDiscoverySource;
 use App\Services\Discovery\HackerNewsDiscoverySource;
+use App\Services\Discovery\ProductHuntDiscoverySource;
 use App\Services\Discovery\TechCrunchDiscoverySource;
 use App\Services\Discovery\WellfoundDiscoverySource;
-use App\Services\Discovery\ProductHuntDiscoverySource;
 use App\Services\Discovery\YCombinatorDiscoverySource;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
@@ -63,18 +63,19 @@ class DiscoverCompaniesService
             : [$sourceName => $this->sources[$sourceName] ?? null];
 
         foreach ($sourcesToRun as $name => $source) {
-            if (!$source) {
+            if (! $source) {
                 $results['errors'][] = "Unknown source: {$name}";
+
                 continue;
             }
 
             try {
                 $candidates = $source->discover($days);
-                Log::info("Discovery [{$name}]: found " . count($candidates) . " candidates");
+                Log::info("Discovery [{$name}]: found ".count($candidates).' candidates');
 
                 foreach ($candidates as $candidate) {
                     $companyName = $candidate['name'] ?? null;
-                    if (!$companyName) {
+                    if (! $companyName) {
                         continue;
                     }
 
@@ -83,7 +84,7 @@ class DiscoverCompaniesService
                     // Check if company already exists (by name or domain)
                     $existing = Company::whereRaw('LOWER(name) = ?', [strtolower($companyName)])->first();
 
-                    if (!$existing && !empty($candidate['website'])) {
+                    if (! $existing && ! empty($candidate['website'])) {
                         $domain = $this->extractDomain($candidate['website']);
                         if ($domain) {
                             $existing = Company::where('website', 'LIKE', "%{$domain}%")->first();
@@ -96,6 +97,7 @@ class DiscoverCompaniesService
                             'source' => $name,
                             'existing_id' => $existing->id,
                         ];
+
                         continue;
                     }
 
@@ -104,6 +106,7 @@ class DiscoverCompaniesService
                             'source' => $name,
                             'dry_run' => true,
                         ]);
+
                         continue;
                     }
 
@@ -148,9 +151,10 @@ class DiscoverCompaniesService
     private function extractDomain(string $url): ?string
     {
         $host = parse_url($url, PHP_URL_HOST);
-        if (!$host) {
+        if (! $host) {
             return null;
         }
+
         // Strip www.
         return preg_replace('/^www\./', '', strtolower($host));
     }

--- a/app/Services/Discovery/CompaniesHouseService.php
+++ b/app/Services/Discovery/CompaniesHouseService.php
@@ -20,7 +20,7 @@ class CompaniesHouseService
      */
     public function search(string $query, int $startIndex = 0, int $itemsPerPage = 50): array
     {
-        if (!$this->apiKey) {
+        if (! $this->apiKey) {
             throw new \RuntimeException('Companies House API key not configured. Set COMPANIES_HOUSE_KEY in .env');
         }
 
@@ -31,8 +31,9 @@ class CompaniesHouseService
                 'items_per_page' => $itemsPerPage,
             ]);
 
-        if (!$response->successful()) {
+        if (! $response->successful()) {
             Log::error('Companies House API error', ['status' => $response->status()]);
+
             return ['companies' => [], 'total' => 0];
         }
 

--- a/app/Services/Discovery/CrunchbaseDiscoverySource.php
+++ b/app/Services/Discovery/CrunchbaseDiscoverySource.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Facades\Log;
 class CrunchbaseDiscoverySource implements CompanyDiscoverySource
 {
     private const API_BASE = 'https://api.crunchbase.com/api/v4';
+
     private const ODM_BASE = 'https://api.crunchbase.com/odm/v4';
 
     public function name(): string
@@ -22,6 +23,7 @@ class CrunchbaseDiscoverySource implements CompanyDiscoverySource
 
         if (empty($apiKey)) {
             Log::info('Crunchbase discovery skipped: CRUNCHBASE_API_KEY not set');
+
             return [];
         }
 
@@ -29,6 +31,7 @@ class CrunchbaseDiscoverySource implements CompanyDiscoverySource
             return $this->discoverViaApi($apiKey, $days);
         } catch (\Exception $e) {
             Log::warning("Crunchbase discovery error: {$e->getMessage()}");
+
             return [];
         }
     }
@@ -41,7 +44,7 @@ class CrunchbaseDiscoverySource implements CompanyDiscoverySource
         $response = Http::withHeaders([
             'X-cb-user-key' => $apiKey,
             'Content-Type' => 'application/json',
-        ])->timeout(30)->retry(2, 1000)->post(self::API_BASE . '/searches/organizations', [
+        ])->timeout(30)->retry(2, 1000)->post(self::API_BASE.'/searches/organizations', [
             'field_ids' => [
                 'identifier',
                 'short_description',
@@ -76,16 +79,19 @@ class CrunchbaseDiscoverySource implements CompanyDiscoverySource
 
         if ($response->status() === 401 || $response->status() === 403) {
             Log::warning('Crunchbase API key invalid or insufficient permissions');
+
             return [];
         }
 
         if ($response->status() === 429) {
             Log::warning('Crunchbase API rate limit hit, backing off');
+
             return [];
         }
 
-        if (!$response->successful()) {
+        if (! $response->successful()) {
             Log::warning("Crunchbase API error: HTTP {$response->status()}");
+
             return $this->discoverViaOdm($apiKey, $days);
         }
 
@@ -105,13 +111,14 @@ class CrunchbaseDiscoverySource implements CompanyDiscoverySource
 
             $response = Http::withHeaders([
                 'X-cb-user-key' => $apiKey,
-            ])->timeout(30)->get(self::ODM_BASE . '/odm-organizations', [
+            ])->timeout(30)->get(self::ODM_BASE.'/odm-organizations', [
                 'updated_after' => $sinceDate,
                 'sort_order' => 'updated_at DESC',
             ]);
 
-            if (!$response->successful()) {
+            if (! $response->successful()) {
                 Log::warning("Crunchbase ODM error: HTTP {$response->status()}");
+
                 return [];
             }
 
@@ -121,6 +128,7 @@ class CrunchbaseDiscoverySource implements CompanyDiscoverySource
             return $this->parseEntities($entities);
         } catch (\Exception $e) {
             Log::warning("Crunchbase ODM error: {$e->getMessage()}");
+
             return [];
         }
     }
@@ -133,7 +141,7 @@ class CrunchbaseDiscoverySource implements CompanyDiscoverySource
             $props = $entity['properties'] ?? [];
             $name = $props['identifier']['value'] ?? ($props['name'] ?? null);
 
-            if (!$name) {
+            if (! $name) {
                 continue;
             }
 
@@ -148,7 +156,7 @@ class CrunchbaseDiscoverySource implements CompanyDiscoverySource
 
             // Extract location
             $locations = $props['location_identifiers'] ?? [];
-            if (!empty($locations)) {
+            if (! empty($locations)) {
                 $locationParts = array_column($locations, 'value');
                 $company['location'] = implode(', ', $locationParts);
             }

--- a/app/Services/Discovery/GitHubOrgDiscoveryService.php
+++ b/app/Services/Discovery/GitHubOrgDiscoveryService.php
@@ -34,8 +34,9 @@ class GitHubOrgDiscoveryService
             'page' => $page,
         ]);
 
-        if (!$response->successful()) {
+        if (! $response->successful()) {
             Log::error('GitHub API error', ['status' => $response->status()]);
+
             return ['orgs' => [], 'total' => 0];
         }
 

--- a/app/Services/Discovery/HackerNewsDiscoverySource.php
+++ b/app/Services/Discovery/HackerNewsDiscoverySource.php
@@ -36,10 +36,11 @@ class HackerNewsDiscoverySource implements CompanyDiscoverySource
     private function fetchStoryIds(string $feed): array
     {
         $response = Http::timeout(15)->retry(2, 1000)
-            ->get(self::API_BASE . "/{$feed}.json");
+            ->get(self::API_BASE."/{$feed}.json");
 
-        if (!$response->successful()) {
+        if (! $response->successful()) {
             Log::warning("HackerNews API error fetching {$feed}: HTTP {$response->status()}");
+
             return [];
         }
 
@@ -56,7 +57,7 @@ class HackerNewsDiscoverySource implements CompanyDiscoverySource
         foreach ($ids as $id) {
             try {
                 $item = $this->fetchItem($id);
-                if (!$item) {
+                if (! $item) {
                     continue;
                 }
 
@@ -69,7 +70,7 @@ class HackerNewsDiscoverySource implements CompanyDiscoverySource
                 $title = $item['title'] ?? '';
 
                 // Filter for Show HN / Launch HN posts
-                if (!preg_match('/^(Show HN|Launch HN)\s*:\s*/i', $title, $matches)) {
+                if (! preg_match('/^(Show HN|Launch HN)\s*:\s*/i', $title, $matches)) {
                     continue;
                 }
 
@@ -93,6 +94,7 @@ class HackerNewsDiscoverySource implements CompanyDiscoverySource
                 $wordCount = str_word_count($companyName);
                 if ($wordCount > 6) {
                     Log::debug("HackerNews: Skipping likely non-company name: {$companyName}");
+
                     continue;
                 }
 
@@ -100,6 +102,7 @@ class HackerNewsDiscoverySource implements CompanyDiscoverySource
                 if (preg_match('/\b(that|which|for|with|how|what|this|your|the|and|from|using)\b/i', $companyName)
                     && $wordCount > 3) {
                     Log::debug("HackerNews: Skipping descriptive title: {$companyName}");
+
                     continue;
                 }
 
@@ -132,9 +135,9 @@ class HackerNewsDiscoverySource implements CompanyDiscoverySource
 
     private function fetchItem(int $id): ?array
     {
-        $response = Http::timeout(10)->get(self::API_BASE . "/item/{$id}.json");
+        $response = Http::timeout(10)->get(self::API_BASE."/item/{$id}.json");
 
-        if (!$response->successful()) {
+        if (! $response->successful()) {
             return null;
         }
 

--- a/app/Services/Discovery/ProductHuntDiscoveryService.php
+++ b/app/Services/Discovery/ProductHuntDiscoveryService.php
@@ -2,8 +2,6 @@
 
 namespace App\Services\Discovery;
 
-use App\Models\Company;
-use App\Models\CompanyImport;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 
@@ -22,7 +20,7 @@ class ProductHuntDiscoveryService
      */
     public function discover(int $limit = 50, ?string $cursor = null): array
     {
-        if (!$this->token) {
+        if (! $this->token) {
             throw new \RuntimeException('Product Hunt API token not configured. Set PRODUCTHUNT_TOKEN in .env');
         }
 
@@ -55,8 +53,9 @@ class ProductHuntDiscoveryService
             'variables' => ['first' => $limit, 'after' => $cursor],
         ]);
 
-        if (!$response->successful()) {
+        if (! $response->successful()) {
             Log::error('Product Hunt API error', ['status' => $response->status()]);
+
             return ['companies' => [], 'cursor' => null, 'hasMore' => false];
         }
 

--- a/app/Services/Discovery/ProductHuntDiscoverySource.php
+++ b/app/Services/Discovery/ProductHuntDiscoverySource.php
@@ -47,6 +47,7 @@ class ProductHuntDiscoverySource implements CompanyDiscoverySource
         }
 
         Log::info('ProductHunt: No API token configured, falling back to web scraping');
+
         return $this->discoverViaScraping();
     }
 
@@ -100,21 +101,21 @@ class ProductHuntDiscoverySource implements CompanyDiscoverySource
                         ],
                     ]);
 
-                if (!$response->successful()) {
+                if (! $response->successful()) {
                     Log::warning("ProductHunt API error: HTTP {$response->status()}");
                     break;
                 }
 
                 $data = $response->json('data.posts');
-                if (!$data) {
+                if (! $data) {
                     break;
                 }
 
                 foreach ($data['edges'] as $edge) {
                     $post = $edge['node'];
-                    $combined = strtolower(($post['tagline'] ?? '') . ' ' . ($post['description'] ?? ''));
+                    $combined = strtolower(($post['tagline'] ?? '').' '.($post['description'] ?? ''));
 
-                    if (!$this->hasIndieSignals($combined, $post)) {
+                    if (! $this->hasIndieSignals($combined, $post)) {
                         continue;
                     }
 
@@ -128,7 +129,7 @@ class ProductHuntDiscoverySource implements CompanyDiscoverySource
                     ];
                 }
 
-                if (!($data['pageInfo']['hasNextPage'] ?? false)) {
+                if (! ($data['pageInfo']['hasNextPage'] ?? false)) {
                     break;
                 }
 
@@ -154,8 +155,9 @@ class ProductHuntDiscoverySource implements CompanyDiscoverySource
                 ])
                 ->get('https://www.producthunt.com/leaderboard/daily');
 
-            if (!$response->successful()) {
+            if (! $response->successful()) {
                 Log::warning("ProductHunt scrape error: HTTP {$response->status()}");
+
                 return [];
             }
 

--- a/app/Services/Discovery/TechCrunchDiscoverySource.php
+++ b/app/Services/Discovery/TechCrunchDiscoverySource.php
@@ -4,7 +4,6 @@ namespace App\Services\Discovery;
 
 use App\Contracts\CompanyDiscoverySource;
 use App\Services\TechCrunchService;
-use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 
 class TechCrunchDiscoverySource implements CompanyDiscoverySource
@@ -24,8 +23,9 @@ class TechCrunchDiscoverySource implements CompanyDiscoverySource
     {
         $result = $this->techCrunchService->scrapeFundraisingArticles();
 
-        if (!$result['success']) {
+        if (! $result['success']) {
             Log::warning("TechCrunch discovery failed: {$result['error']}");
+
             return [];
         }
 
@@ -72,7 +72,7 @@ class TechCrunchDiscoverySource implements CompanyDiscoverySource
             }
         }
 
-        if (!$companyName || strlen($companyName) < 2 || strlen($companyName) > 100) {
+        if (! $companyName || strlen($companyName) < 2 || strlen($companyName) > 100) {
             return null;
         }
 

--- a/app/Services/Discovery/WellfoundDiscoverySource.php
+++ b/app/Services/Discovery/WellfoundDiscoverySource.php
@@ -22,13 +22,14 @@ class WellfoundDiscoverySource implements CompanyDiscoverySource
         try {
             $companies = $this->discoverViaGraphQL();
 
-            if (!empty($companies)) {
+            if (! empty($companies)) {
                 return $companies;
             }
 
             return $this->discoverViaScrape();
         } catch (\Exception $e) {
             Log::warning("Wellfound discovery error: {$e->getMessage()}");
+
             return [];
         }
     }
@@ -80,8 +81,9 @@ class WellfoundDiscoverySource implements CompanyDiscoverySource
                 GRAPHQL,
             ]);
 
-            if (!$response->successful()) {
+            if (! $response->successful()) {
                 Log::info("Wellfound GraphQL returned HTTP {$response->status()}, falling back to scrape");
+
                 return [];
             }
 
@@ -97,7 +99,7 @@ class WellfoundDiscoverySource implements CompanyDiscoverySource
                 $node = $edge['node'] ?? [];
                 $name = $node['name'] ?? null;
 
-                if (!$name) {
+                if (! $name) {
                     continue;
                 }
 
@@ -112,7 +114,7 @@ class WellfoundDiscoverySource implements CompanyDiscoverySource
 
                 // Location
                 $locations = $node['locationTags'] ?? [];
-                if (!empty($locations)) {
+                if (! empty($locations)) {
                     $company['location'] = $locations[0]['displayName'] ?? null;
                 }
 
@@ -133,6 +135,7 @@ class WellfoundDiscoverySource implements CompanyDiscoverySource
             return $companies;
         } catch (\Exception $e) {
             Log::info("Wellfound GraphQL failed: {$e->getMessage()}");
+
             return [];
         }
     }
@@ -154,17 +157,18 @@ class WellfoundDiscoverySource implements CompanyDiscoverySource
                     'Accept' => 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
                 ])->timeout(30)->get($url);
 
-                if (!$response->successful()) {
+                if (! $response->successful()) {
                     continue;
                 }
 
                 $companies = $this->parseHtml($response->body());
 
-                if (!empty($companies)) {
+                if (! empty($companies)) {
                     return $companies;
                 }
             } catch (\Exception $e) {
                 Log::info("Wellfound scrape of {$url} failed: {$e->getMessage()}");
+
                 continue;
             }
         }
@@ -185,7 +189,7 @@ class WellfoundDiscoverySource implements CompanyDiscoverySource
 
             foreach (array_slice($startups, 0, 50) as $startup) {
                 $name = $startup['name'] ?? null;
-                if (!$name) {
+                if (! $name) {
                     continue;
                 }
 
@@ -222,6 +226,6 @@ class WellfoundDiscoverySource implements CompanyDiscoverySource
             }
         }
 
-        return array_filter($companies, fn ($c) => !empty($c['name']));
+        return array_filter($companies, fn ($c) => ! empty($c['name']));
     }
 }

--- a/app/Services/Discovery/YCombinatorDiscoverySource.php
+++ b/app/Services/Discovery/YCombinatorDiscoverySource.php
@@ -10,7 +10,9 @@ class YCombinatorDiscoverySource implements CompanyDiscoverySource
 {
     // YC's Algolia-powered API for their company directory
     private const API_URL = 'https://45bwzj1sgc-dsn.algolia.net/1/indexes/YCCompany_production/query';
+
     private const APP_ID = '45bwzj1sgc';
+
     private const API_KEY = 'MjBjYjRiMzY0NzdhZWY0NjExY2NhZjYxMGIxYjc2MTAwNWFkNTkwNTc4NjgxYjU0YzFhYTY2ZGQ5OGY5NDMxZnJlc3RyaWN0SW5kaWNlcz0lNUIlMjJZQ0NvbXBhbnlfcHJvZHVjdGlvbiUyMiUyQyUyMllDQ29tcGFueV9CeV9MYXVuY2hfRGF0ZV9wcm9kdWN0aW9uJTIyJTVEJnRhZ0ZpbHRlcnM9JTVCJTIyeWNkY19wdWJsaWMlMjIlNUQmYW5hbHl0aWNzVGFncz0lNUIlMjJ5Y2RjJTIyJTVE';
 
     public function name(): string
@@ -34,8 +36,9 @@ class YCombinatorDiscoverySource implements CompanyDiscoverySource
                 'facetFilters' => $this->getRecentBatchFilters(),
             ]);
 
-            if (!$response->successful()) {
+            if (! $response->successful()) {
                 Log::warning("YC discovery failed: HTTP {$response->status()}");
+
                 return $this->fallbackScrape();
             }
 
@@ -45,6 +48,7 @@ class YCombinatorDiscoverySource implements CompanyDiscoverySource
             return $this->parseAlgoliaHits($hits);
         } catch (\Exception $e) {
             Log::warning("YC discovery error: {$e->getMessage()}");
+
             return $this->fallbackScrape();
         }
     }
@@ -60,8 +64,8 @@ class YCombinatorDiscoverySource implements CompanyDiscoverySource
         $batches[] = "batch:W{$year}";
         $batches[] = "batch:S{$year}";
         // Previous year's batches
-        $batches[] = "batch:W" . ($year - 1);
-        $batches[] = "batch:S" . ($year - 1);
+        $batches[] = 'batch:W'.($year - 1);
+        $batches[] = 'batch:S'.($year - 1);
 
         return [$batches]; // OR within the array
     }
@@ -72,7 +76,7 @@ class YCombinatorDiscoverySource implements CompanyDiscoverySource
 
         foreach ($hits as $hit) {
             $name = $hit['name'] ?? null;
-            if (!$name) {
+            if (! $name) {
                 continue;
             }
 
@@ -102,7 +106,7 @@ class YCombinatorDiscoverySource implements CompanyDiscoverySource
                 'User-Agent' => 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36',
             ])->timeout(30)->get('https://www.ycombinator.com/companies?batch=latest');
 
-            if (!$response->successful()) {
+            if (! $response->successful()) {
                 return [];
             }
 
@@ -130,6 +134,7 @@ class YCombinatorDiscoverySource implements CompanyDiscoverySource
             return $companies;
         } catch (\Exception $e) {
             Log::warning("YC fallback scrape failed: {$e->getMessage()}");
+
             return [];
         }
     }

--- a/app/Services/FundingRoundDeduplicationService.php
+++ b/app/Services/FundingRoundDeduplicationService.php
@@ -34,10 +34,10 @@ class FundingRoundDeduplicationService
     /**
      * Check if a funding round would be a duplicate of an existing round.
      *
-     * @param int $companyId The company ID
-     * @param string $announcedDate The announced date (YYYY-MM-DD)
-     * @param float|null $amount The funding amount in USD
-     * @param Collection|null $existingRounds Pre-loaded rounds to avoid extra queries
+     * @param  int  $companyId  The company ID
+     * @param  string  $announcedDate  The announced date (YYYY-MM-DD)
+     * @param  float|null  $amount  The funding amount in USD
+     * @param  Collection|null  $existingRounds  Pre-loaded rounds to avoid extra queries
      * @return FundingRound|null Returns the potential duplicate round, or null if no duplicate found
      */
     public function findPotentialDuplicate(int $companyId, string $announcedDate, ?float $amount, ?Collection $existingRounds = null): ?FundingRound
@@ -56,15 +56,14 @@ class FundingRoundDeduplicationService
     /**
      * Check if a specific round is a potential duplicate of new data.
      *
-     * @param FundingRound $existingRound The existing funding round
-     * @param string $newDate The new announced date (YYYY-MM-DD)
-     * @param float|null $newAmount The new funding amount
-     * @return bool
+     * @param  FundingRound  $existingRound  The existing funding round
+     * @param  string  $newDate  The new announced date (YYYY-MM-DD)
+     * @param  float|null  $newAmount  The new funding amount
      */
     public function isPotentialDuplicate(FundingRound $existingRound, string $newDate, ?float $newAmount): bool
     {
         // Check date proximity
-        if (!$this->areDatesWithinTolerance($existingRound->announced_date, $newDate)) {
+        if (! $this->areDatesWithinTolerance($existingRound->announced_date, $newDate)) {
             return false;
         }
 
@@ -89,7 +88,7 @@ class FundingRoundDeduplicationService
      * Uses eager-loaded fundingRounds relation when a Company model is passed,
      * avoiding an extra query if the relation is already loaded.
      *
-     * @param Company|int $company The company or company ID
+     * @param  Company|int  $company  The company or company ID
      * @return Collection Collection of arrays with 'round1' and 'round2' keys
      */
     public function findDuplicatesForCompany(Company|int $company): Collection
@@ -171,9 +170,7 @@ class FundingRoundDeduplicationService
     /**
      * Check if two dates are within the tolerance window.
      *
-     * @param \Carbon\Carbon|string $date1
-     * @param string $date2
-     * @return bool
+     * @param  \Carbon\Carbon|string  $date1
      */
     protected function areDatesWithinTolerance($date1, string $date2): bool
     {
@@ -185,10 +182,6 @@ class FundingRoundDeduplicationService
 
     /**
      * Check if two amounts are within the tolerance percentage.
-     *
-     * @param float $amount1
-     * @param float $amount2
-     * @return bool
      */
     protected function areAmountsWithinTolerance(float $amount1, float $amount2): bool
     {
@@ -209,10 +202,6 @@ class FundingRoundDeduplicationService
 
     /**
      * Calculate the percentage difference between two amounts.
-     *
-     * @param float|null $amount1
-     * @param float|null $amount2
-     * @return float|null
      */
     protected function calculateAmountDiffPercent(?float $amount1, ?float $amount2): ?float
     {
@@ -236,32 +225,26 @@ class FundingRoundDeduplicationService
 
     /**
      * Set the date tolerance in days.
-     *
-     * @param int $days
-     * @return self
      */
     public function setDateTolerance(int $days): self
     {
         $this->dateTolerance = $days;
+
         return $this;
     }
 
     /**
      * Set the amount tolerance as a decimal (e.g., 0.10 for 10%).
-     *
-     * @param float $tolerance
-     * @return self
      */
     public function setAmountTolerance(float $tolerance): self
     {
         $this->amountTolerance = $tolerance;
+
         return $this;
     }
 
     /**
      * Get the current date tolerance.
-     *
-     * @return int
      */
     public function getDateTolerance(): int
     {
@@ -270,8 +253,6 @@ class FundingRoundDeduplicationService
 
     /**
      * Get the current amount tolerance.
-     *
-     * @return float
      */
     public function getAmountTolerance(): float
     {

--- a/app/Services/GitHubDiscoveryService.php
+++ b/app/Services/GitHubDiscoveryService.php
@@ -18,6 +18,7 @@ class GitHubDiscoveryService
     ];
 
     private const MIN_STARS = 500;
+
     private const AWESOME_SELFHOSTED_REPO = 'awesome-selfhosted/awesome-selfhosted';
 
     private ?string $token;
@@ -71,14 +72,14 @@ class GitHubDiscoveryService
         $page = 1;
         do {
             $response = $this->githubRequest('https://api.github.com/search/repositories', [
-                'q' => "topic:{$topic} stars:>" . self::MIN_STARS . " pushed:>{$pushedAfter}",
+                'q' => "topic:{$topic} stars:>".self::MIN_STARS." pushed:>{$pushedAfter}",
                 'sort' => 'stars',
                 'order' => 'desc',
                 'per_page' => 100,
                 'page' => $page,
             ]);
 
-            if (!$response->successful()) {
+            if (! $response->successful()) {
                 Log::warning("GitHub search failed for topic '{$topic}': {$response->status()}");
                 break;
             }
@@ -108,13 +109,14 @@ class GitHubDiscoveryService
         $stats = ['created' => 0, 'updated' => 0];
 
         $response = $this->githubRequest(
-            'https://api.github.com/repos/' . self::AWESOME_SELFHOSTED_REPO . '/readme',
+            'https://api.github.com/repos/'.self::AWESOME_SELFHOSTED_REPO.'/readme',
             [],
             ['Accept' => 'application/vnd.github.raw']
         );
 
-        if (!$response->successful()) {
-            Log::warning('Failed to fetch awesome-selfhosted README: ' . $response->status());
+        if (! $response->successful()) {
+            Log::warning('Failed to fetch awesome-selfhosted README: '.$response->status());
+
             return $stats;
         }
 
@@ -142,7 +144,7 @@ class GitHubDiscoveryService
                     "https://api.github.com/repos/{$match[3]}/{$match[4]}"
                 );
 
-                if (!$repoResponse->successful()) {
+                if (! $repoResponse->successful()) {
                     continue;
                 }
 
@@ -194,10 +196,12 @@ class GitHubDiscoveryService
 
         if ($existing) {
             $existing->update($data);
+
             return 'updated';
         }
 
         OpenSourceProject::create($data);
+
         return 'created';
     }
 

--- a/app/Services/LinkedInService.php
+++ b/app/Services/LinkedInService.php
@@ -18,7 +18,7 @@ class LinkedInService
                 'Accept-Language' => 'en-US,en;q=0.5',
             ])->timeout(30)->get($linkedinUrl);
 
-            if (!$response->successful()) {
+            if (! $response->successful()) {
                 return [
                     'success' => false,
                     'headcount' => null,

--- a/app/Services/NewsSearchService.php
+++ b/app/Services/NewsSearchService.php
@@ -24,7 +24,6 @@ class NewsSearchService
      *
      * Uses TechCrunch's search functionality to find articles mentioning the company name.
      *
-     * @param Company $company
      * @return array{success: bool, articles: array, error: string|null}
      */
     public function searchCompanyNews(Company $company): array
@@ -39,7 +38,7 @@ class NewsSearchService
                 'Accept' => 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
             ])->timeout(30)->get($searchUrl);
 
-            if (!$response->successful()) {
+            if (! $response->successful()) {
                 return [
                     'success' => false,
                     'articles' => [],
@@ -68,10 +67,6 @@ class NewsSearchService
 
     /**
      * Parse TechCrunch search results HTML to extract articles.
-     *
-     * @param string $html
-     * @param string $companyName
-     * @return array
      */
     private function parseSearchResults(string $html, string $companyName): array
     {
@@ -92,7 +87,7 @@ class NewsSearchService
             $title = trim(strip_tags(html_entity_decode($match[2], ENT_QUOTES | ENT_HTML5, 'UTF-8')));
 
             // Skip if the title doesn't actually mention the company
-            if (!$this->titleMentionsCompany($title, $companyName)) {
+            if (! $this->titleMentionsCompany($title, $companyName)) {
                 continue;
             }
 
@@ -112,7 +107,7 @@ class NewsSearchService
         $seen = [];
         $unique = [];
         foreach ($articles as $article) {
-            if (!isset($seen[$article['url']])) {
+            if (! isset($seen[$article['url']])) {
                 $seen[$article['url']] = true;
                 $unique[] = $article;
             }
@@ -139,10 +134,6 @@ class NewsSearchService
      *
      * For ambiguous names (common English words), requires the name to appear
      * in a company-specific context (e.g., near funding verbs or dollar amounts).
-     *
-     * @param string $title
-     * @param string $companyName
-     * @return bool
      */
     private function titleMentionsCompany(string $title, string $companyName): bool
     {
@@ -152,17 +143,17 @@ class NewsSearchService
         }
 
         // Check if company name appears as a whole word
-        $pattern = '/\b' . preg_quote($companyName, '/') . '\b/i';
-        if (!preg_match($pattern, $title)) {
+        $pattern = '/\b'.preg_quote($companyName, '/').'\b/i';
+        if (! preg_match($pattern, $title)) {
             return false;
         }
 
         // For ambiguous/common-word names, require stronger context
         if (in_array(strtolower($companyName), self::AMBIGUOUS_NAMES) || strlen($companyName) <= 5) {
-            $fundingContext = '/(' . preg_quote($companyName, '/') . '\s+(raises|raised|secures|secured|closes|closed|lands|announces)'
-                . '|' . preg_quote($companyName, '/') . ',?\s+(a|the|an)\s+\w+\s+(startup|company|platform)'
-                . '|\$[\d.]+\s*(million|billion|M|B)\b.*\b' . preg_quote($companyName, '/')
-                . '|\b' . preg_quote($companyName, '/') . '\b.*\$[\d.]+\s*(million|billion|M|B))/i';
+            $fundingContext = '/('.preg_quote($companyName, '/').'\s+(raises|raised|secures|secured|closes|closed|lands|announces)'
+                .'|'.preg_quote($companyName, '/').',?\s+(a|the|an)\s+\w+\s+(startup|company|platform)'
+                .'|\$[\d.]+\s*(million|billion|M|B)\b.*\b'.preg_quote($companyName, '/')
+                .'|\b'.preg_quote($companyName, '/').'\b.*\$[\d.]+\s*(million|billion|M|B))/i';
 
             return (bool) preg_match($fundingContext, $title);
         }
@@ -173,7 +164,6 @@ class NewsSearchService
     /**
      * Extract publication date from TechCrunch article URL.
      *
-     * @param string $url
      * @return string|null Date in Y-m-d format
      */
     private function extractDateFromUrl(string $url): ?string
@@ -184,9 +174,11 @@ class NewsSearchService
                     ?->format('Y-m-d');
             } catch (\Exception $e) {
                 Log::debug("Invalid date in URL {$url}: {$e->getMessage()}");
+
                 return null;
             }
         }
+
         return null;
     }
 }

--- a/app/Services/TechCrunchService.php
+++ b/app/Services/TechCrunchService.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Facades\Log;
 class TechCrunchService
 {
     private const FUNDRAISING_URL = 'https://techcrunch.com/tag/fundraising/';
+
     private const USER_AGENT = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36';
 
     public function scrapeFundraisingArticles(): array
@@ -20,7 +21,7 @@ class TechCrunchService
                 'Accept' => 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
             ])->timeout(30)->get(self::FUNDRAISING_URL);
 
-            if (!$response->successful()) {
+            if (! $response->successful()) {
                 return [
                     'success' => false,
                     'articles' => [],
@@ -67,7 +68,7 @@ class TechCrunchService
         foreach ($articles as $article) {
             $title = $article['title'] ?? '';
             $content = $article['excerpt'] ?? '';
-            $text = $title . ' ' . $content;
+            $text = $title.' '.$content;
 
             foreach ($companies as $companyId => $companyName) {
                 // Skip very short names to avoid false positives
@@ -75,7 +76,7 @@ class TechCrunchService
                     continue;
                 }
 
-                if (!$this->isConfidentMatch($companyName, $title, $text)) {
+                if (! $this->isConfidentMatch($companyName, $title, $text)) {
                     continue;
                 }
 
@@ -102,20 +103,20 @@ class TechCrunchService
      */
     private function isConfidentMatch(string $companyName, string $title, string $fullText): bool
     {
-        $pattern = '/\b' . preg_quote($companyName, '/') . '\b/i';
+        $pattern = '/\b'.preg_quote($companyName, '/').'\b/i';
 
         // Check if the name appears at all
-        if (!preg_match($pattern, $fullText)) {
+        if (! preg_match($pattern, $fullText)) {
             return false;
         }
 
         // For ambiguous/common-word names, require stronger signals
         if (in_array(strtolower($companyName), self::AMBIGUOUS_NAMES) || strlen($companyName) <= 5) {
             // Must appear in a funding context: near a dollar amount, "raises", "series", etc.
-            $fundingContext = '/(' . preg_quote($companyName, '/') . '\s+(raises|raised|secures|secured|closes|closed|lands|announces)'
-                . '|' . preg_quote($companyName, '/') . ',?\s+(a|the|an)\s+\w+\s+(startup|company|platform)'
-                . '|\$[\d.]+\s*(million|billion|M|B)\b.*\b' . preg_quote($companyName, '/')
-                . '|\b' . preg_quote($companyName, '/') . '\b.*\$[\d.]+\s*(million|billion|M|B))/i';
+            $fundingContext = '/('.preg_quote($companyName, '/').'\s+(raises|raised|secures|secured|closes|closed|lands|announces)'
+                .'|'.preg_quote($companyName, '/').',?\s+(a|the|an)\s+\w+\s+(startup|company|platform)'
+                .'|\$[\d.]+\s*(million|billion|M|B)\b.*\b'.preg_quote($companyName, '/')
+                .'|\b'.preg_quote($companyName, '/').'\b.*\$[\d.]+\s*(million|billion|M|B))/i';
 
             return (bool) preg_match($fundingContext, $fullText);
         }
@@ -154,7 +155,7 @@ class TechCrunchService
         $seen = [];
         $unique = [];
         foreach ($articles as $article) {
-            if (!isset($seen[$article['url']])) {
+            if (! isset($seen[$article['url']])) {
                 $seen[$article['url']] = true;
                 $unique[] = $article;
             }
@@ -208,7 +209,7 @@ class TechCrunchService
         foreach ($roundPatterns as $pattern => $prefix) {
             if (preg_match($pattern, $text, $roundMatch)) {
                 if ($prefix === 'series_') {
-                    $info['round_type'] = 'series_' . strtolower($roundMatch[1]);
+                    $info['round_type'] = 'series_'.strtolower($roundMatch[1]);
                 } else {
                     $info['round_type'] = $prefix;
                 }
@@ -216,6 +217,6 @@ class TechCrunchService
             }
         }
 
-        return !empty($info) ? $info : null;
+        return ! empty($info) ? $info : null;
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
         "laravel/sail": "^1.41",
         "mockery/mockery": "^1.6",
         "nunomaduro/collision": "^8.6",
+        "pestphp/pest": "^3.8",
         "phpunit/phpunit": "^11.5.3"
     },
     "autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bdc6d92507d397adf1c269ed49ec424d",
+    "content-hash": "f4dcb00231126a5d7d4cff2d828012c7",
     "packages": [
         {
             "name": "brick/math",
@@ -2441,31 +2441,31 @@
         },
         {
             "name": "nunomaduro/termwind",
-            "version": "v2.3.3",
+            "version": "v2.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nunomaduro/termwind.git",
-                "reference": "6fb2a640ff502caace8e05fd7be3b503a7e1c017"
+                "reference": "712a31b768f5daea284c2169a7d227031001b9a8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nunomaduro/termwind/zipball/6fb2a640ff502caace8e05fd7be3b503a7e1c017",
-                "reference": "6fb2a640ff502caace8e05fd7be3b503a7e1c017",
+                "url": "https://api.github.com/repos/nunomaduro/termwind/zipball/712a31b768f5daea284c2169a7d227031001b9a8",
+                "reference": "712a31b768f5daea284c2169a7d227031001b9a8",
                 "shasum": ""
             },
             "require": {
                 "ext-mbstring": "*",
                 "php": "^8.2",
-                "symfony/console": "^7.3.6"
+                "symfony/console": "^7.4.4 || ^8.0.4"
             },
             "require-dev": {
-                "illuminate/console": "^11.46.1",
-                "laravel/pint": "^1.25.1",
+                "illuminate/console": "^11.47.0",
+                "laravel/pint": "^1.27.1",
                 "mockery/mockery": "^1.6.12",
-                "pestphp/pest": "^2.36.0 || ^3.8.4 || ^4.1.3",
+                "pestphp/pest": "^2.36.0 || ^3.8.4 || ^4.3.2",
                 "phpstan/phpstan": "^1.12.32",
                 "phpstan/phpstan-strict-rules": "^1.6.2",
-                "symfony/var-dumper": "^7.3.5",
+                "symfony/var-dumper": "^7.3.5 || ^8.0.4",
                 "thecodingmachine/phpstan-strict-rules": "^1.0.0"
             },
             "type": "library",
@@ -2497,7 +2497,7 @@
                     "email": "enunomaduro@gmail.com"
                 }
             ],
-            "description": "Its like Tailwind CSS, but for the console.",
+            "description": "It's like Tailwind CSS, but for the console.",
             "keywords": [
                 "cli",
                 "console",
@@ -2508,7 +2508,7 @@
             ],
             "support": {
                 "issues": "https://github.com/nunomaduro/termwind/issues",
-                "source": "https://github.com/nunomaduro/termwind/tree/v2.3.3"
+                "source": "https://github.com/nunomaduro/termwind/tree/v2.4.0"
             },
             "funding": [
                 {
@@ -2524,7 +2524,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-11-20T02:34:59+00:00"
+            "time": "2026-02-16T23:10:27+00:00"
         },
         {
             "name": "phpoption/phpoption",
@@ -3369,16 +3369,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v7.4.1",
+            "version": "v7.4.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "6d9f0fbf2ec2e9785880096e3abd0ca0c88b506e"
+                "reference": "41e38717ac1dd7a46b6bda7d6a82af2d98a78894"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/6d9f0fbf2ec2e9785880096e3abd0ca0c88b506e",
-                "reference": "6d9f0fbf2ec2e9785880096e3abd0ca0c88b506e",
+                "url": "https://api.github.com/repos/symfony/console/zipball/41e38717ac1dd7a46b6bda7d6a82af2d98a78894",
+                "reference": "41e38717ac1dd7a46b6bda7d6a82af2d98a78894",
                 "shasum": ""
             },
             "require": {
@@ -3443,7 +3443,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v7.4.1"
+                "source": "https://github.com/symfony/console/tree/v7.4.4"
             },
             "funding": [
                 {
@@ -3463,7 +3463,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-12-05T15:23:39+00:00"
+            "time": "2026-01-13T11:36:38+00:00"
         },
         {
             "name": "symfony/css-selector",
@@ -3846,16 +3846,16 @@
         },
         {
             "name": "symfony/finder",
-            "version": "v7.4.0",
+            "version": "v7.4.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "340b9ed7320570f319028a2cbec46d40535e94bd"
+                "reference": "ad4daa7c38668dcb031e63bc99ea9bd42196a2cb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/340b9ed7320570f319028a2cbec46d40535e94bd",
-                "reference": "340b9ed7320570f319028a2cbec46d40535e94bd",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/ad4daa7c38668dcb031e63bc99ea9bd42196a2cb",
+                "reference": "ad4daa7c38668dcb031e63bc99ea9bd42196a2cb",
                 "shasum": ""
             },
             "require": {
@@ -3890,7 +3890,7 @@
             "description": "Finds files and directories via an intuitive fluent interface",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/finder/tree/v7.4.0"
+                "source": "https://github.com/symfony/finder/tree/v7.4.5"
             },
             "funding": [
                 {
@@ -3910,7 +3910,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-11-05T05:42:40+00:00"
+            "time": "2026-01-26T15:07:59+00:00"
         },
         {
             "name": "symfony/http-foundation",
@@ -5354,16 +5354,16 @@
         },
         {
             "name": "symfony/string",
-            "version": "v8.0.1",
+            "version": "v8.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "ba65a969ac918ce0cc3edfac6cdde847eba231dc"
+                "reference": "758b372d6882506821ed666032e43020c4f57194"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/ba65a969ac918ce0cc3edfac6cdde847eba231dc",
-                "reference": "ba65a969ac918ce0cc3edfac6cdde847eba231dc",
+                "url": "https://api.github.com/repos/symfony/string/zipball/758b372d6882506821ed666032e43020c4f57194",
+                "reference": "758b372d6882506821ed666032e43020c4f57194",
                 "shasum": ""
             },
             "require": {
@@ -5420,7 +5420,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v8.0.1"
+                "source": "https://github.com/symfony/string/tree/v8.0.4"
             },
             "funding": [
                 {
@@ -5440,7 +5440,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-12-01T09:13:36+00:00"
+            "time": "2026-01-12T12:37:40+00:00"
         },
         {
             "name": "symfony/translation",
@@ -5998,6 +5998,147 @@
     ],
     "packages-dev": [
         {
+            "name": "brianium/paratest",
+            "version": "v7.8.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/paratestphp/paratest.git",
+                "reference": "9b324c8fc319cf9728b581c7a90e1c8f6361c5e5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/paratestphp/paratest/zipball/9b324c8fc319cf9728b581c7a90e1c8f6361c5e5",
+                "reference": "9b324c8fc319cf9728b581c7a90e1c8f6361c5e5",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-pcre": "*",
+                "ext-reflection": "*",
+                "ext-simplexml": "*",
+                "fidry/cpu-core-counter": "^1.3.0",
+                "jean85/pretty-package-versions": "^2.1.1",
+                "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
+                "phpunit/php-code-coverage": "^11.0.12",
+                "phpunit/php-file-iterator": "^5.1.0",
+                "phpunit/php-timer": "^7.0.1",
+                "phpunit/phpunit": "^11.5.46",
+                "sebastian/environment": "^7.2.1",
+                "symfony/console": "^6.4.22 || ^7.3.4 || ^8.0.3",
+                "symfony/process": "^6.4.20 || ^7.3.4 || ^8.0.3"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^12.0.0",
+                "ext-pcov": "*",
+                "ext-posix": "*",
+                "phpstan/phpstan": "^2.1.33",
+                "phpstan/phpstan-deprecation-rules": "^2.0.3",
+                "phpstan/phpstan-phpunit": "^2.0.11",
+                "phpstan/phpstan-strict-rules": "^2.0.7",
+                "squizlabs/php_codesniffer": "^3.13.5",
+                "symfony/filesystem": "^6.4.13 || ^7.3.2 || ^8.0.1"
+            },
+            "bin": [
+                "bin/paratest",
+                "bin/paratest_for_phpstorm"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "ParaTest\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Brian Scaturro",
+                    "email": "scaturrob@gmail.com",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Filippo Tessarotto",
+                    "email": "zoeslam@gmail.com",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Parallel testing for PHP",
+            "homepage": "https://github.com/paratestphp/paratest",
+            "keywords": [
+                "concurrent",
+                "parallel",
+                "phpunit",
+                "testing"
+            ],
+            "support": {
+                "issues": "https://github.com/paratestphp/paratest/issues",
+                "source": "https://github.com/paratestphp/paratest/tree/v7.8.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sponsors/Slamdunk",
+                    "type": "github"
+                },
+                {
+                    "url": "https://paypal.me/filippotessarotto",
+                    "type": "paypal"
+                }
+            ],
+            "time": "2026-01-08T08:02:38+00:00"
+        },
+        {
+            "name": "doctrine/deprecations",
+            "version": "1.1.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/deprecations.git",
+                "reference": "d4fe3e6fd9bb9e72557a19674f44d8ac7db4c6ca"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/deprecations/zipball/d4fe3e6fd9bb9e72557a19674f44d8ac7db4c6ca",
+                "reference": "d4fe3e6fd9bb9e72557a19674f44d8ac7db4c6ca",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<=7.5 || >=14"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^9 || ^12 || ^14",
+                "phpstan/phpstan": "1.4.10 || 2.1.30",
+                "phpstan/phpstan-phpunit": "^1.0 || ^2",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.6 || ^10.5 || ^11.5 || ^12.4 || ^13.0",
+                "psr/log": "^1 || ^2 || ^3"
+            },
+            "suggest": {
+                "psr/log": "Allows logging deprecations via PSR-3 logger implementation"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Deprecations\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "A small layer on top of trigger_error(E_USER_DEPRECATED) or PSR-3 logging with options to disable all deprecations or selectively for packages.",
+            "homepage": "https://www.doctrine-project.org/",
+            "support": {
+                "issues": "https://github.com/doctrine/deprecations/issues",
+                "source": "https://github.com/doctrine/deprecations/tree/1.1.6"
+            },
+            "time": "2026-02-07T07:09:04+00:00"
+        },
+        {
             "name": "fakerphp/faker",
             "version": "v1.24.1",
             "source": {
@@ -6059,6 +6200,67 @@
                 "source": "https://github.com/FakerPHP/Faker/tree/v1.24.1"
             },
             "time": "2024-11-21T13:46:39+00:00"
+        },
+        {
+            "name": "fidry/cpu-core-counter",
+            "version": "1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theofidry/cpu-core-counter.git",
+                "reference": "db9508f7b1474469d9d3c53b86f817e344732678"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theofidry/cpu-core-counter/zipball/db9508f7b1474469d9d3c53b86f817e344732678",
+                "reference": "db9508f7b1474469d9d3c53b86f817e344732678",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "require-dev": {
+                "fidry/makefile": "^0.2.0",
+                "fidry/php-cs-fixer-config": "^1.1.2",
+                "phpstan/extension-installer": "^1.2.0",
+                "phpstan/phpstan": "^2.0",
+                "phpstan/phpstan-deprecation-rules": "^2.0.0",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpstan/phpstan-strict-rules": "^2.0",
+                "phpunit/phpunit": "^8.5.31 || ^9.5.26",
+                "webmozarts/strict-phpunit": "^7.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Fidry\\CpuCoreCounter\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Théo FIDRY",
+                    "email": "theo.fidry@gmail.com"
+                }
+            ],
+            "description": "Tiny utility to get the number of CPU cores.",
+            "keywords": [
+                "CPU",
+                "core"
+            ],
+            "support": {
+                "issues": "https://github.com/theofidry/cpu-core-counter/issues",
+                "source": "https://github.com/theofidry/cpu-core-counter/tree/1.3.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theofidry",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-08-14T07:29:31+00:00"
         },
         {
             "name": "filp/whoops",
@@ -6181,6 +6383,66 @@
                 "source": "https://github.com/hamcrest/hamcrest-php/tree/v2.1.1"
             },
             "time": "2025-04-30T06:54:44+00:00"
+        },
+        {
+            "name": "jean85/pretty-package-versions",
+            "version": "2.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Jean85/pretty-package-versions.git",
+                "reference": "4d7aa5dab42e2a76d99559706022885de0e18e1a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Jean85/pretty-package-versions/zipball/4d7aa5dab42e2a76d99559706022885de0e18e1a",
+                "reference": "4d7aa5dab42e2a76d99559706022885de0e18e1a",
+                "shasum": ""
+            },
+            "require": {
+                "composer-runtime-api": "^2.1.0",
+                "php": "^7.4|^8.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^3.2",
+                "jean85/composer-provided-replaced-stub-package": "^1.0",
+                "phpstan/phpstan": "^2.0",
+                "phpunit/phpunit": "^7.5|^8.5|^9.6",
+                "rector/rector": "^2.0",
+                "vimeo/psalm": "^4.3 || ^5.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Jean85\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Alessandro Lai",
+                    "email": "alessandro.lai85@gmail.com"
+                }
+            ],
+            "description": "A library to get pretty versions strings of installed dependencies",
+            "keywords": [
+                "composer",
+                "package",
+                "release",
+                "versions"
+            ],
+            "support": {
+                "issues": "https://github.com/Jean85/pretty-package-versions/issues",
+                "source": "https://github.com/Jean85/pretty-package-versions/tree/2.1.1"
+            },
+            "time": "2025-03-19T14:43:43+00:00"
         },
         {
             "name": "laravel/breeze",
@@ -6597,39 +6859,36 @@
         },
         {
             "name": "nunomaduro/collision",
-            "version": "v8.8.3",
+            "version": "v8.9.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nunomaduro/collision.git",
-                "reference": "1dc9e88d105699d0fee8bb18890f41b274f6b4c4"
+                "reference": "a1ed3fa530fd60bc515f9303e8520fcb7d4bd935"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nunomaduro/collision/zipball/1dc9e88d105699d0fee8bb18890f41b274f6b4c4",
-                "reference": "1dc9e88d105699d0fee8bb18890f41b274f6b4c4",
+                "url": "https://api.github.com/repos/nunomaduro/collision/zipball/a1ed3fa530fd60bc515f9303e8520fcb7d4bd935",
+                "reference": "a1ed3fa530fd60bc515f9303e8520fcb7d4bd935",
                 "shasum": ""
             },
             "require": {
-                "filp/whoops": "^2.18.1",
-                "nunomaduro/termwind": "^2.3.1",
+                "filp/whoops": "^2.18.4",
+                "nunomaduro/termwind": "^2.4.0",
                 "php": "^8.2.0",
-                "symfony/console": "^7.3.0"
+                "symfony/console": "^7.4.4 || ^8.0.4"
             },
             "conflict": {
-                "laravel/framework": "<11.44.2 || >=13.0.0",
-                "phpunit/phpunit": "<11.5.15 || >=13.0.0"
+                "laravel/framework": "<11.48.0 || >=14.0.0",
+                "phpunit/phpunit": "<11.5.50 || >=14.0.0"
             },
             "require-dev": {
-                "brianium/paratest": "^7.8.3",
-                "larastan/larastan": "^3.4.2",
-                "laravel/framework": "^11.44.2 || ^12.18",
-                "laravel/pint": "^1.22.1",
-                "laravel/sail": "^1.43.1",
-                "laravel/sanctum": "^4.1.1",
-                "laravel/tinker": "^2.10.1",
-                "orchestra/testbench-core": "^9.12.0 || ^10.4",
-                "pestphp/pest": "^3.8.2 || ^4.0.0",
-                "sebastian/environment": "^7.2.1 || ^8.0"
+                "brianium/paratest": "^7.8.5",
+                "larastan/larastan": "^3.9.2",
+                "laravel/framework": "^11.48.0 || ^12.52.0",
+                "laravel/pint": "^1.27.1",
+                "orchestra/testbench-core": "^9.12.0 || ^10.9.0",
+                "pestphp/pest": "^3.8.5 || ^4.4.1 || ^5.0.0",
+                "sebastian/environment": "^7.2.1 || ^8.0.3 || ^9.0.0"
             },
             "type": "library",
             "extra": {
@@ -6692,7 +6951,331 @@
                     "type": "patreon"
                 }
             ],
-            "time": "2025-11-20T02:55:25+00:00"
+            "time": "2026-02-17T17:33:08+00:00"
+        },
+        {
+            "name": "pestphp/pest",
+            "version": "v3.8.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/pestphp/pest.git",
+                "reference": "7796630eafcfd1c02660cecdde3bc6984fbf01f4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/pestphp/pest/zipball/7796630eafcfd1c02660cecdde3bc6984fbf01f4",
+                "reference": "7796630eafcfd1c02660cecdde3bc6984fbf01f4",
+                "shasum": ""
+            },
+            "require": {
+                "brianium/paratest": "^7.8.5",
+                "nunomaduro/collision": "^8.8.3",
+                "nunomaduro/termwind": "^2.3.3",
+                "pestphp/pest-plugin": "^3.0.0",
+                "pestphp/pest-plugin-arch": "^3.1.1",
+                "pestphp/pest-plugin-mutate": "^3.0.5",
+                "php": "^8.2.0",
+                "phpunit/phpunit": "^11.5.50"
+            },
+            "conflict": {
+                "filp/whoops": "<2.16.0",
+                "phpunit/phpunit": ">11.5.50",
+                "sebastian/exporter": "<6.0.0",
+                "webmozart/assert": "<1.11.0"
+            },
+            "require-dev": {
+                "pestphp/pest-dev-tools": "^3.4.0",
+                "pestphp/pest-plugin-type-coverage": "^3.6.1",
+                "symfony/process": "^7.4.4"
+            },
+            "bin": [
+                "bin/pest"
+            ],
+            "type": "library",
+            "extra": {
+                "pest": {
+                    "plugins": [
+                        "Pest\\Mutate\\Plugins\\Mutate",
+                        "Pest\\Plugins\\Configuration",
+                        "Pest\\Plugins\\Bail",
+                        "Pest\\Plugins\\Cache",
+                        "Pest\\Plugins\\Coverage",
+                        "Pest\\Plugins\\Init",
+                        "Pest\\Plugins\\Environment",
+                        "Pest\\Plugins\\Help",
+                        "Pest\\Plugins\\Memory",
+                        "Pest\\Plugins\\Only",
+                        "Pest\\Plugins\\Printer",
+                        "Pest\\Plugins\\ProcessIsolation",
+                        "Pest\\Plugins\\Profile",
+                        "Pest\\Plugins\\Retry",
+                        "Pest\\Plugins\\Snapshot",
+                        "Pest\\Plugins\\Verbose",
+                        "Pest\\Plugins\\Version",
+                        "Pest\\Plugins\\Parallel"
+                    ]
+                },
+                "phpstan": {
+                    "includes": [
+                        "extension.neon"
+                    ]
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/Functions.php",
+                    "src/Pest.php"
+                ],
+                "psr-4": {
+                    "Pest\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nuno Maduro",
+                    "email": "enunomaduro@gmail.com"
+                }
+            ],
+            "description": "The elegant PHP Testing Framework.",
+            "keywords": [
+                "framework",
+                "pest",
+                "php",
+                "test",
+                "testing",
+                "unit"
+            ],
+            "support": {
+                "issues": "https://github.com/pestphp/pest/issues",
+                "source": "https://github.com/pestphp/pest/tree/v3.8.5"
+            },
+            "funding": [
+                {
+                    "url": "https://www.paypal.com/paypalme/enunomaduro",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/nunomaduro",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-01-28T01:33:45+00:00"
+        },
+        {
+            "name": "pestphp/pest-plugin",
+            "version": "v3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/pestphp/pest-plugin.git",
+                "reference": "e79b26c65bc11c41093b10150c1341cc5cdbea83"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/pestphp/pest-plugin/zipball/e79b26c65bc11c41093b10150c1341cc5cdbea83",
+                "reference": "e79b26c65bc11c41093b10150c1341cc5cdbea83",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^2.0.0",
+                "composer-runtime-api": "^2.2.2",
+                "php": "^8.2"
+            },
+            "conflict": {
+                "pestphp/pest": "<3.0.0"
+            },
+            "require-dev": {
+                "composer/composer": "^2.7.9",
+                "pestphp/pest": "^3.0.0",
+                "pestphp/pest-dev-tools": "^3.0.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Pest\\Plugin\\Manager"
+            },
+            "autoload": {
+                "psr-4": {
+                    "Pest\\Plugin\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "The Pest plugin manager",
+            "keywords": [
+                "framework",
+                "manager",
+                "pest",
+                "php",
+                "plugin",
+                "test",
+                "testing",
+                "unit"
+            ],
+            "support": {
+                "source": "https://github.com/pestphp/pest-plugin/tree/v3.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=66BYDWAT92N6L",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/nunomaduro",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/nunomaduro",
+                    "type": "patreon"
+                }
+            ],
+            "time": "2024-09-08T23:21:41+00:00"
+        },
+        {
+            "name": "pestphp/pest-plugin-arch",
+            "version": "v3.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/pestphp/pest-plugin-arch.git",
+                "reference": "db7bd9cb1612b223e16618d85475c6f63b9c8daa"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/pestphp/pest-plugin-arch/zipball/db7bd9cb1612b223e16618d85475c6f63b9c8daa",
+                "reference": "db7bd9cb1612b223e16618d85475c6f63b9c8daa",
+                "shasum": ""
+            },
+            "require": {
+                "pestphp/pest-plugin": "^3.0.0",
+                "php": "^8.2",
+                "ta-tikoma/phpunit-architecture-test": "^0.8.4"
+            },
+            "require-dev": {
+                "pestphp/pest": "^3.8.1",
+                "pestphp/pest-dev-tools": "^3.4.0"
+            },
+            "type": "library",
+            "extra": {
+                "pest": {
+                    "plugins": [
+                        "Pest\\Arch\\Plugin"
+                    ]
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/Autoload.php"
+                ],
+                "psr-4": {
+                    "Pest\\Arch\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "The Arch plugin for Pest PHP.",
+            "keywords": [
+                "arch",
+                "architecture",
+                "framework",
+                "pest",
+                "php",
+                "plugin",
+                "test",
+                "testing",
+                "unit"
+            ],
+            "support": {
+                "source": "https://github.com/pestphp/pest-plugin-arch/tree/v3.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://www.paypal.com/paypalme/enunomaduro",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/nunomaduro",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-04-16T22:59:48+00:00"
+        },
+        {
+            "name": "pestphp/pest-plugin-mutate",
+            "version": "v3.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/pestphp/pest-plugin-mutate.git",
+                "reference": "e10dbdc98c9e2f3890095b4fe2144f63a5717e08"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/pestphp/pest-plugin-mutate/zipball/e10dbdc98c9e2f3890095b4fe2144f63a5717e08",
+                "reference": "e10dbdc98c9e2f3890095b4fe2144f63a5717e08",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^5.2.0",
+                "pestphp/pest-plugin": "^3.0.0",
+                "php": "^8.2",
+                "psr/simple-cache": "^3.0.0"
+            },
+            "require-dev": {
+                "pestphp/pest": "^3.0.8",
+                "pestphp/pest-dev-tools": "^3.0.0",
+                "pestphp/pest-plugin-type-coverage": "^3.0.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Pest\\Mutate\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Sandro Gehri",
+                    "email": "sandrogehri@gmail.com"
+                }
+            ],
+            "description": "Mutates your code to find untested cases",
+            "keywords": [
+                "framework",
+                "mutate",
+                "mutation",
+                "pest",
+                "php",
+                "plugin",
+                "test",
+                "testing",
+                "unit"
+            ],
+            "support": {
+                "source": "https://github.com/pestphp/pest-plugin-mutate/tree/v3.0.5"
+            },
+            "funding": [
+                {
+                    "url": "https://www.paypal.com/paypalme/enunomaduro",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/gehrisandro",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nunomaduro",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-09-22T07:54:40+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -6811,6 +7394,229 @@
                 "source": "https://github.com/phar-io/version/tree/3.2.1"
             },
             "time": "2022-02-21T01:04:05+00:00"
+        },
+        {
+            "name": "phpdocumentor/reflection-common",
+            "version": "2.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
+                "reference": "1d01c49d4ed62f25aa84a747ad35d5a16924662b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/1d01c49d4ed62f25aa84a747ad35d5a16924662b",
+                "reference": "1d01c49d4ed62f25aa84a747ad35d5a16924662b",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-2.x": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jaap van Otterdijk",
+                    "email": "opensource@ijaap.nl"
+                }
+            ],
+            "description": "Common reflection classes used by phpdocumentor to reflect the code structure",
+            "homepage": "http://www.phpdoc.org",
+            "keywords": [
+                "FQSEN",
+                "phpDocumentor",
+                "phpdoc",
+                "reflection",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/phpDocumentor/ReflectionCommon/issues",
+                "source": "https://github.com/phpDocumentor/ReflectionCommon/tree/2.x"
+            },
+            "time": "2020-06-27T09:03:43+00:00"
+        },
+        {
+            "name": "phpdocumentor/reflection-docblock",
+            "version": "6.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
+                "reference": "2f5cbed597cb261d1ea458f3da3a9ad32e670b1e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/2f5cbed597cb261d1ea458f3da3a9ad32e670b1e",
+                "reference": "2f5cbed597cb261d1ea458f3da3a9ad32e670b1e",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/deprecations": "^1.1",
+                "ext-filter": "*",
+                "php": "^7.4 || ^8.0",
+                "phpdocumentor/reflection-common": "^2.2",
+                "phpdocumentor/type-resolver": "^2.0",
+                "phpstan/phpdoc-parser": "^2.0",
+                "webmozart/assert": "^1.9.1 || ^2"
+            },
+            "require-dev": {
+                "mockery/mockery": "~1.3.5 || ~1.6.0",
+                "phpstan/extension-installer": "^1.1",
+                "phpstan/phpstan": "^1.8",
+                "phpstan/phpstan-mockery": "^1.1",
+                "phpstan/phpstan-webmozart-assert": "^1.2",
+                "phpunit/phpunit": "^9.5",
+                "psalm/phar": "^5.26",
+                "shipmonk/dead-code-detector": "^0.5.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "me@mikevanriel.com"
+                },
+                {
+                    "name": "Jaap van Otterdijk",
+                    "email": "opensource@ijaap.nl"
+                }
+            ],
+            "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
+            "support": {
+                "issues": "https://github.com/phpDocumentor/ReflectionDocBlock/issues",
+                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/6.0.1"
+            },
+            "time": "2026-01-20T15:30:42+00:00"
+        },
+        {
+            "name": "phpdocumentor/type-resolver",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/TypeResolver.git",
+                "reference": "327a05bbee54120d4786a0dc67aad30226ad4cf9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/327a05bbee54120d4786a0dc67aad30226ad4cf9",
+                "reference": "327a05bbee54120d4786a0dc67aad30226ad4cf9",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/deprecations": "^1.0",
+                "php": "^7.4 || ^8.0",
+                "phpdocumentor/reflection-common": "^2.0",
+                "phpstan/phpdoc-parser": "^2.0"
+            },
+            "require-dev": {
+                "ext-tokenizer": "*",
+                "phpbench/phpbench": "^1.2",
+                "phpstan/extension-installer": "^1.4",
+                "phpstan/phpstan": "^2.1",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpunit/phpunit": "^9.5",
+                "psalm/phar": "^4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-1.x": "1.x-dev",
+                    "dev-2.x": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "me@mikevanriel.com"
+                }
+            ],
+            "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
+            "support": {
+                "issues": "https://github.com/phpDocumentor/TypeResolver/issues",
+                "source": "https://github.com/phpDocumentor/TypeResolver/tree/2.0.0"
+            },
+            "time": "2026-01-06T21:53:42+00:00"
+        },
+        {
+            "name": "phpstan/phpdoc-parser",
+            "version": "2.3.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpdoc-parser.git",
+                "reference": "a004701b11273a26cd7955a61d67a7f1e525a45a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/a004701b11273a26cd7955a61d67a7f1e525a45a",
+                "reference": "a004701b11273a26cd7955a61d67a7f1e525a45a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "doctrine/annotations": "^2.0",
+                "nikic/php-parser": "^5.3.0",
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/extension-installer": "^1.0",
+                "phpstan/phpstan": "^2.0",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpstan/phpstan-strict-rules": "^2.0",
+                "phpunit/phpunit": "^9.6",
+                "symfony/process": "^5.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\PhpDocParser\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPDoc parser with support for nullable, intersection and generic types",
+            "support": {
+                "issues": "https://github.com/phpstan/phpdoc-parser/issues",
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/2.3.2"
+            },
+            "time": "2026-01-25T14:56:51+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -7161,16 +7967,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "11.5.53",
+            "version": "11.5.50",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "a997a653a82845f1240d73ee73a8a4e97e4b0607"
+                "reference": "fdfc727f0fcacfeb8fcb30c7e5da173125b58be3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/a997a653a82845f1240d73ee73a8a4e97e4b0607",
-                "reference": "a997a653a82845f1240d73ee73a8a4e97e4b0607",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/fdfc727f0fcacfeb8fcb30c7e5da173125b58be3",
+                "reference": "fdfc727f0fcacfeb8fcb30c7e5da173125b58be3",
                 "shasum": ""
             },
             "require": {
@@ -7185,7 +7991,7 @@
                 "phar-io/version": "^3.2.1",
                 "php": ">=8.2",
                 "phpunit/php-code-coverage": "^11.0.12",
-                "phpunit/php-file-iterator": "^5.1.1",
+                "phpunit/php-file-iterator": "^5.1.0",
                 "phpunit/php-invoker": "^5.0.1",
                 "phpunit/php-text-template": "^4.0.1",
                 "phpunit/php-timer": "^7.0.1",
@@ -7197,7 +8003,6 @@
                 "sebastian/exporter": "^6.3.2",
                 "sebastian/global-state": "^7.0.2",
                 "sebastian/object-enumerator": "^6.0.1",
-                "sebastian/recursion-context": "^6.0.3",
                 "sebastian/type": "^5.1.3",
                 "sebastian/version": "^5.0.2",
                 "staabm/side-effects-detector": "^1.0.5"
@@ -7243,7 +8048,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/11.5.53"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/11.5.50"
             },
             "funding": [
                 {
@@ -7267,7 +8072,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-02-10T12:28:25+00:00"
+            "time": "2026-01-27T05:59:18+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -8384,6 +9189,65 @@
             "time": "2025-12-04T18:11:45+00:00"
         },
         {
+            "name": "ta-tikoma/phpunit-architecture-test",
+            "version": "0.8.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ta-tikoma/phpunit-architecture-test.git",
+                "reference": "1248f3f506ca9641d4f68cebcd538fa489754db8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ta-tikoma/phpunit-architecture-test/zipball/1248f3f506ca9641d4f68cebcd538fa489754db8",
+                "reference": "1248f3f506ca9641d4f68cebcd538fa489754db8",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^4.18.0 || ^5.0.0",
+                "php": "^8.1.0",
+                "phpdocumentor/reflection-docblock": "^5.3.0 || ^6.0.0",
+                "phpunit/phpunit": "^10.5.5 || ^11.0.0 || ^12.0.0 || ^13.0.0",
+                "symfony/finder": "^6.4.0 || ^7.0.0 || ^8.0.0"
+            },
+            "require-dev": {
+                "laravel/pint": "^1.13.7",
+                "phpstan/phpstan": "^1.10.52"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PHPUnit\\Architecture\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ni Shi",
+                    "email": "futik0ma011@gmail.com"
+                },
+                {
+                    "name": "Nuno Maduro",
+                    "email": "enunomaduro@gmail.com"
+                }
+            ],
+            "description": "Methods for testing application architecture",
+            "keywords": [
+                "architecture",
+                "phpunit",
+                "stucture",
+                "test",
+                "testing"
+            ],
+            "support": {
+                "issues": "https://github.com/ta-tikoma/phpunit-architecture-test/issues",
+                "source": "https://github.com/ta-tikoma/phpunit-architecture-test/tree/0.8.7"
+            },
+            "time": "2026-02-17T17:25:14+00:00"
+        },
+        {
             "name": "theseer/tokenizer",
             "version": "1.3.1",
             "source": {
@@ -8432,6 +9296,68 @@
                 }
             ],
             "time": "2025-11-17T20:03:58+00:00"
+        },
+        {
+            "name": "webmozart/assert",
+            "version": "2.1.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webmozarts/assert.git",
+                "reference": "79155f94852fa27e2f73b459f6503f5e87e2c188"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webmozarts/assert/zipball/79155f94852fa27e2f73b459f6503f5e87e2c188",
+                "reference": "79155f94852fa27e2f73b459f6503f5e87e2c188",
+                "shasum": ""
+            },
+            "require": {
+                "ext-ctype": "*",
+                "ext-date": "*",
+                "ext-filter": "*",
+                "php": "^8.2"
+            },
+            "suggest": {
+                "ext-intl": "",
+                "ext-simplexml": "",
+                "ext-spl": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-feature/2-0": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Webmozart\\Assert\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                },
+                {
+                    "name": "Woody Gilk",
+                    "email": "woody.gilk@gmail.com"
+                }
+            ],
+            "description": "Assertions to validate method input/output with nice error messages.",
+            "keywords": [
+                "assert",
+                "check",
+                "validate"
+            ],
+            "support": {
+                "issues": "https://github.com/webmozarts/assert/issues",
+                "source": "https://github.com/webmozarts/assert/tree/2.1.5"
+            },
+            "time": "2026-02-18T14:09:36+00:00"
         }
     ],
     "aliases": [],

--- a/database/factories/PersonFactory.php
+++ b/database/factories/PersonFactory.php
@@ -15,7 +15,7 @@ class PersonFactory extends Factory
             'name' => fake()->name(),
             'slug' => fake()->unique()->slug(),
             'bio' => fake()->sentence(),
-            'linkedin_url' => 'https://linkedin.com/in/' . fake()->slug(),
+            'linkedin_url' => 'https://linkedin.com/in/'.fake()->slug(),
         ];
     }
 }

--- a/database/migrations/2026_02_16_220000_add_status_tracking_to_companies_table.php
+++ b/database/migrations/2026_02_16_220000_add_status_tracking_to_companies_table.php
@@ -9,16 +9,16 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('companies', function (Blueprint $table) {
-            if (!Schema::hasColumn('companies', 'status')) {
+            if (! Schema::hasColumn('companies', 'status')) {
                 $table->string('status', 20)->default('operating')->after('country');
             }
-            if (!Schema::hasColumn('companies', 'closed_at')) {
+            if (! Schema::hasColumn('companies', 'closed_at')) {
                 $table->date('closed_at')->nullable()->after('status');
             }
-            if (!Schema::hasColumn('companies', 'acquired_by')) {
+            if (! Schema::hasColumn('companies', 'acquired_by')) {
                 $table->string('acquired_by')->nullable()->after('closed_at');
             }
-            if (!Schema::hasColumn('companies', 'import_source')) {
+            if (! Schema::hasColumn('companies', 'import_source')) {
                 $table->string('import_source')->nullable()->after('acquired_by');
             }
         });

--- a/database/seeders/AdditionalFundingDataSeeder.php
+++ b/database/seeders/AdditionalFundingDataSeeder.php
@@ -6,7 +6,6 @@ use App\Models\Company;
 use App\Models\FundingRound;
 use App\Models\Investor;
 use Illuminate\Database\Seeder;
-use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
 
 /**
@@ -159,11 +158,14 @@ class AdditionalFundingDataSeeder extends Seeder
     private function seedXaiFunding(array $investors): void
     {
         $company = Company::where('slug', 'xai')->first();
-        if (!$company) {
+        if (! $company) {
             $this->command->warn('Company not found: xai');
+
             return;
         }
-        if ($company->fundingRounds()->exists()) return;
+        if ($company->fundingRounds()->exists()) {
+            return;
+        }
 
         $rounds = [
             [
@@ -205,11 +207,14 @@ class AdditionalFundingDataSeeder extends Seeder
     private function seedScaleAiFunding(array $investors): void
     {
         $company = Company::where('slug', 'scale-ai')->first();
-        if (!$company) {
+        if (! $company) {
             $this->command->warn('Company not found: scale-ai');
+
             return;
         }
-        if ($company->fundingRounds()->exists()) return;
+        if ($company->fundingRounds()->exists()) {
+            return;
+        }
 
         $rounds = [
             [
@@ -267,11 +272,14 @@ class AdditionalFundingDataSeeder extends Seeder
     private function seedCohereFunding(array $investors): void
     {
         $company = Company::where('slug', 'cohere')->first();
-        if (!$company) {
+        if (! $company) {
             $this->command->warn('Company not found: cohere');
+
             return;
         }
-        if ($company->fundingRounds()->exists()) return;
+        if ($company->fundingRounds()->exists()) {
+            return;
+        }
 
         $rounds = [
             [
@@ -318,11 +326,14 @@ class AdditionalFundingDataSeeder extends Seeder
     private function seedMistralAiFunding(array $investors): void
     {
         $company = Company::where('slug', 'mistral-ai')->first();
-        if (!$company) {
+        if (! $company) {
             $this->command->warn('Company not found: mistral-ai');
+
             return;
         }
-        if ($company->fundingRounds()->exists()) return;
+        if ($company->fundingRounds()->exists()) {
+            return;
+        }
 
         $rounds = [
             [
@@ -372,11 +383,14 @@ class AdditionalFundingDataSeeder extends Seeder
     private function seedHuggingFaceFunding(array $investors): void
     {
         $company = Company::where('slug', 'hugging-face')->first();
-        if (!$company) {
+        if (! $company) {
             $this->command->warn('Company not found: hugging-face');
+
             return;
         }
-        if ($company->fundingRounds()->exists()) return;
+        if ($company->fundingRounds()->exists()) {
+            return;
+        }
 
         $rounds = [
             [
@@ -420,11 +434,14 @@ class AdditionalFundingDataSeeder extends Seeder
     private function seedRunwayFunding(array $investors): void
     {
         $company = Company::where('slug', 'runway')->first();
-        if (!$company) {
+        if (! $company) {
             $this->command->warn('Company not found: runway');
+
             return;
         }
-        if ($company->fundingRounds()->exists()) return;
+        if ($company->fundingRounds()->exists()) {
+            return;
+        }
 
         $rounds = [
             [
@@ -469,11 +486,14 @@ class AdditionalFundingDataSeeder extends Seeder
     private function seedHarveyFunding(array $investors): void
     {
         $company = Company::where('slug', 'harvey')->first();
-        if (!$company) {
+        if (! $company) {
             $this->command->warn('Company not found: harvey');
+
             return;
         }
-        if ($company->fundingRounds()->exists()) return;
+        if ($company->fundingRounds()->exists()) {
+            return;
+        }
 
         $rounds = [
             [
@@ -534,11 +554,14 @@ class AdditionalFundingDataSeeder extends Seeder
     private function seedFigureAiFunding(array $investors): void
     {
         $company = Company::where('slug', 'figure-ai')->first();
-        if (!$company) {
+        if (! $company) {
             $this->command->warn('Company not found: figure-ai');
+
             return;
         }
-        if ($company->fundingRounds()->exists()) return;
+        if ($company->fundingRounds()->exists()) {
+            return;
+        }
 
         $rounds = [
             [
@@ -571,11 +594,14 @@ class AdditionalFundingDataSeeder extends Seeder
     private function seedPlaidFunding(array $investors): void
     {
         $company = Company::where('slug', 'plaid')->first();
-        if (!$company) {
+        if (! $company) {
             $this->command->warn('Company not found: plaid');
+
             return;
         }
-        if ($company->fundingRounds()->exists()) return;
+        if ($company->fundingRounds()->exists()) {
+            return;
+        }
 
         $rounds = [
             [
@@ -628,11 +654,14 @@ class AdditionalFundingDataSeeder extends Seeder
     private function seedBrexFunding(array $investors): void
     {
         $company = Company::where('slug', 'brex')->first();
-        if (!$company) {
+        if (! $company) {
             $this->command->warn('Company not found: brex');
+
             return;
         }
-        if ($company->fundingRounds()->exists()) return;
+        if ($company->fundingRounds()->exists()) {
+            return;
+        }
 
         $rounds = [
             [
@@ -692,11 +721,14 @@ class AdditionalFundingDataSeeder extends Seeder
     private function seedRampFunding(array $investors): void
     {
         $company = Company::where('slug', 'ramp')->first();
-        if (!$company) {
+        if (! $company) {
             $this->command->warn('Company not found: ramp');
+
             return;
         }
-        if ($company->fundingRounds()->exists()) return;
+        if ($company->fundingRounds()->exists()) {
+            return;
+        }
 
         $rounds = [
             [
@@ -775,11 +807,14 @@ class AdditionalFundingDataSeeder extends Seeder
     private function seedChimeFunding(array $investors): void
     {
         $company = Company::where('slug', 'chime')->first();
-        if (!$company) {
+        if (! $company) {
             $this->command->warn('Company not found: chime');
+
             return;
         }
-        if ($company->fundingRounds()->exists()) return;
+        if ($company->fundingRounds()->exists()) {
+            return;
+        }
 
         $rounds = [
             [
@@ -847,11 +882,14 @@ class AdditionalFundingDataSeeder extends Seeder
     private function seedWizFunding(array $investors): void
     {
         $company = Company::where('slug', 'wiz')->first();
-        if (!$company) {
+        if (! $company) {
             $this->command->warn('Company not found: wiz');
+
             return;
         }
-        if ($company->fundingRounds()->exists()) return;
+        if ($company->fundingRounds()->exists()) {
+            return;
+        }
 
         $rounds = [
             [
@@ -906,11 +944,14 @@ class AdditionalFundingDataSeeder extends Seeder
     private function seedAndurilFunding(array $investors): void
     {
         $company = Company::where('slug', 'anduril-industries')->first();
-        if (!$company) {
+        if (! $company) {
             $this->command->warn('Company not found: anduril-industries');
+
             return;
         }
-        if ($company->fundingRounds()->exists()) return;
+        if ($company->fundingRounds()->exists()) {
+            return;
+        }
 
         $rounds = [
             [
@@ -979,11 +1020,14 @@ class AdditionalFundingDataSeeder extends Seeder
     private function seedVercelFunding(array $investors): void
     {
         $company = Company::where('slug', 'vercel')->first();
-        if (!$company) {
+        if (! $company) {
             $this->command->warn('Company not found: vercel');
+
             return;
         }
-        if ($company->fundingRounds()->exists()) return;
+        if ($company->fundingRounds()->exists()) {
+            return;
+        }
 
         $rounds = [
             [
@@ -1043,11 +1087,14 @@ class AdditionalFundingDataSeeder extends Seeder
     private function seedAirtableFunding(array $investors): void
     {
         $company = Company::where('slug', 'airtable')->first();
-        if (!$company) {
+        if (! $company) {
             $this->command->warn('Company not found: airtable');
+
             return;
         }
-        if ($company->fundingRounds()->exists()) return;
+        if ($company->fundingRounds()->exists()) {
+            return;
+        }
 
         $rounds = [
             [
@@ -1109,11 +1156,14 @@ class AdditionalFundingDataSeeder extends Seeder
     private function seedRelativitySpaceFunding(array $investors): void
     {
         $company = Company::where('slug', 'relativity-space')->first();
-        if (!$company) {
+        if (! $company) {
             $this->command->warn('Company not found: relativity-space');
+
             return;
         }
-        if ($company->fundingRounds()->exists()) return;
+        if ($company->fundingRounds()->exists()) {
+            return;
+        }
 
         $rounds = [
             [
@@ -1172,7 +1222,7 @@ class AdditionalFundingDataSeeder extends Seeder
             $roundData['company_id'] = $company->id;
 
             $round = FundingRound::firstOrCreate(
-                ["company_id" => $roundData["company_id"], "announced_date" => $roundData["announced_date"], "round_type" => $roundData["round_type"] ?? null],
+                ['company_id' => $roundData['company_id'], 'announced_date' => $roundData['announced_date'], 'round_type' => $roundData['round_type'] ?? null],
                 $roundData
             );
 

--- a/database/seeders/AsyncWorldwideSeeder.php
+++ b/database/seeders/AsyncWorldwideSeeder.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Company;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Str;
+
+/**
+ * Import remote-first companies from AsyncWorldwide.com directory.
+ *
+ * Run: php artisan db:seed --class=AsyncWorldwideSeeder
+ */
+class AsyncWorldwideSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $companies = [
+            ['Aha!', 'https://www.aha.io/'],
+            ['Appcues', 'https://www.appcues.com/'],
+            ['Arbitrum', 'https://arbitrum.io/'],
+            ['Arkency', 'https://arkency.com/'],
+            ['Automattic', 'https://automattic.com/'],
+            ['Awesome Motive', 'https://awesomemotive.com/'],
+            ['Buffer', 'https://buffer.com/'],
+            ['Chili Piper', 'https://www.chilipiper.com/'],
+            ['Constructor', 'https://constructor.com/'],
+            ['Contra', 'https://contra.com/'],
+            ['Doist', 'https://doist.com/'],
+            ['DuckDuckGo', 'https://duckduckgo.com/'],
+            ['Float', 'https://www.float.com/'],
+            ['FM', 'https://www.fm.co/'],
+            ['Ghost', 'https://ghost.org/'],
+            ['GitLab', 'https://gitlab.com/'],
+            ['Gorilla Logic', 'https://gorillalogic.com/'],
+            ['Groove', 'https://www.groovehq.com/'],
+            ['Interaction Design Foundation', 'https://www.interaction-design.org/'],
+            ['Kinsta', 'https://kinsta.com/'],
+            ['MailerLite', 'https://www.mailerlite.com/'],
+            ['Levity', 'https://levity.ai/'],
+            ['Lightdash', 'https://www.lightdash.com/'],
+            ['Literal Humans', 'https://literalhumans.com/'],
+            ['Liveblocks', 'https://liveblocks.io/'],
+            ['Mailbird', 'https://www.getmailbird.com/'],
+            ['MeetEdgar', 'https://meetedgar.com/'],
+            ['Modash', 'https://www.modash.io/'],
+            ['Namecheap', 'https://www.namecheap.com/'],
+            ['Okta', 'https://www.okta.com/'],
+            ['Omnipresent', 'https://www.omnipresent.com/'],
+            ['Omniscient Digital', 'https://beomniscient.com/'],
+            ['Oyster', 'https://oysterhr.com/'],
+            ['Pitch', 'https://pitch.com/'],
+            ['Plus AI', 'https://plusai.com/'],
+            ['Remote', 'https://remote.com/'],
+            ['SafetyWing', 'https://safetywing.com/'],
+            ['Sanctuary Computer', 'https://www.sanctuary.computer/'],
+            ['ScaleMath', 'https://scalemath.com/'],
+            ['Shogun', 'https://getshogun.com/'],
+            ['SimpleTexting', 'https://simpletexting.com/'],
+            ['Smile.io', 'https://smile.io/'],
+            ['Sporty', 'https://sporty.com/'],
+            ['Springworks', 'https://www.springworks.in/'],
+            ['StackBlitz', 'https://stackblitz.com/'],
+            ['Storylane', 'https://www.storylane.io/'],
+            ['Supabase', 'https://supabase.com/'],
+            ['TestGorilla', 'https://www.testgorilla.com/'],
+            ['Tether', 'https://tether.to/'],
+            ['The Shelf', 'https://www.theshelf.com/'],
+            ['tl;dv', 'https://tldv.io/'],
+            ['Toggl', 'https://toggl.com/'],
+            ['Tortuga', 'https://www.tortugabackpacks.com/'],
+            ['Whereby', 'https://whereby.com/'],
+            ['Windsor.ai', 'https://windsor.ai/'],
+            ['YNAB', 'https://www.ynab.com/'],
+            ['Zapier', 'https://zapier.com/'],
+            ['Zyte', 'https://www.zyte.com/'],
+        ];
+
+        $created = 0;
+        $skipped = 0;
+
+        foreach ($companies as [$name, $website]) {
+            if (Company::where('website', $website)->exists()) {
+                $this->command->info("SKIP: {$name} — already exists");
+                $skipped++;
+                continue;
+            }
+
+            $baseSlug = Str::slug($name);
+            $slug = $baseSlug;
+            $i = 2;
+            while (Company::where('slug', $slug)->exists()) {
+                $slug = $baseSlug.'-'.$i++;
+            }
+
+            Company::create([
+                'name' => $name,
+                'slug' => $slug,
+                'website' => $website,
+                'description' => 'remote-first',
+                'import_source' => 'asyncworldwide.com',
+                'status' => 'operating',
+            ]);
+
+            $this->command->info("CREATED: {$name}");
+            $created++;
+        }
+
+        $this->command->info("Done: {$created} created, {$skipped} skipped.");
+    }
+}

--- a/database/seeders/AsyncWorldwideSeeder.php
+++ b/database/seeders/AsyncWorldwideSeeder.php
@@ -83,6 +83,7 @@ class AsyncWorldwideSeeder extends Seeder
             if (Company::where('website', $website)->exists()) {
                 $this->command->info("SKIP: {$name} — already exists");
                 $skipped++;
+
                 continue;
             }
 

--- a/database/seeders/BackfillCompaniesSeeder.php
+++ b/database/seeders/BackfillCompaniesSeeder.php
@@ -27,7 +27,7 @@ class BackfillCompaniesSeeder extends Seeder
             }
         }
 
-        $this->command->info("Created: {$created}, Updated: {$updated}, Total: " . Company::count());
+        $this->command->info("Created: {$created}, Updated: {$updated}, Total: ".Company::count());
     }
 
     private function getCompanies(): array

--- a/database/seeders/CompanyCategorySeeder.php
+++ b/database/seeders/CompanyCategorySeeder.php
@@ -83,7 +83,7 @@ class CompanyCategorySeeder extends Seeder
         // Report any uncategorized companies
         $uncategorized = Company::whereNull('category')->pluck('name');
         if ($uncategorized->isNotEmpty()) {
-            $this->command->warn("Uncategorized companies: " . $uncategorized->join(', '));
+            $this->command->warn('Uncategorized companies: '.$uncategorized->join(', '));
         }
     }
 }

--- a/database/seeders/CompanyProfileSeeder.php
+++ b/database/seeders/CompanyProfileSeeder.php
@@ -24,7 +24,9 @@ class CompanyProfileSeeder extends Seeder
     private function seedAnthropic(): void
     {
         $company = Company::where('slug', 'anthropic')->first();
-        if (!$company) return;
+        if (! $company) {
+            return;
+        }
 
         $company->update([
             'product_highlights' => [
@@ -50,7 +52,9 @@ class CompanyProfileSeeder extends Seeder
     private function seedOpenAI(): void
     {
         $company = Company::where('slug', 'openai')->first();
-        if (!$company) return;
+        if (! $company) {
+            return;
+        }
 
         $company->update([
             'product_highlights' => [
@@ -75,7 +79,9 @@ class CompanyProfileSeeder extends Seeder
     private function seedStripe(): void
     {
         $company = Company::where('slug', 'stripe')->first();
-        if (!$company) return;
+        if (! $company) {
+            return;
+        }
 
         $company->update([
             'product_highlights' => [
@@ -101,7 +107,9 @@ class CompanyProfileSeeder extends Seeder
     private function seedDatabricks(): void
     {
         $company = Company::where('slug', 'databricks')->first();
-        if (!$company) return;
+        if (! $company) {
+            return;
+        }
 
         $company->update([
             'product_highlights' => [
@@ -127,7 +135,9 @@ class CompanyProfileSeeder extends Seeder
     private function seedFigma(): void
     {
         $company = Company::where('slug', 'figma')->first();
-        if (!$company) return;
+        if (! $company) {
+            return;
+        }
 
         $company->update([
             'product_highlights' => [
@@ -152,7 +162,9 @@ class CompanyProfileSeeder extends Seeder
     private function seedNotion(): void
     {
         $company = Company::where('slug', 'notion')->first();
-        if (!$company) return;
+        if (! $company) {
+            return;
+        }
 
         $company->update([
             'product_highlights' => [
@@ -177,7 +189,9 @@ class CompanyProfileSeeder extends Seeder
     private function seedRippling(): void
     {
         $company = Company::where('slug', 'rippling')->first();
-        if (!$company) return;
+        if (! $company) {
+            return;
+        }
 
         $company->update([
             'product_highlights' => [
@@ -201,7 +215,9 @@ class CompanyProfileSeeder extends Seeder
     private function seedCanva(): void
     {
         $company = Company::where('slug', 'canva')->first();
-        if (!$company) return;
+        if (! $company) {
+            return;
+        }
 
         $company->update([
             'product_highlights' => [
@@ -239,7 +255,7 @@ class CompanyProfileSeeder extends Seeder
             );
 
             // Attach to company if not already attached
-            if (!$company->people()->where('person_id', $person->id)->exists()) {
+            if (! $company->people()->where('person_id', $person->id)->exists()) {
                 $company->people()->attach($person->id, [
                     'role' => $personData['role'],
                     'is_current' => $isCurrent,

--- a/database/seeders/FundingDataSeeder.php
+++ b/database/seeders/FundingDataSeeder.php
@@ -87,7 +87,9 @@ class FundingDataSeeder extends Seeder
     private function seedAnthropicFunding(array $investors): void
     {
         $company = Company::where('slug', 'anthropic')->first();
-        if (!$company) return;
+        if (! $company) {
+            return;
+        }
 
         $rounds = [
             [
@@ -156,7 +158,9 @@ class FundingDataSeeder extends Seeder
     private function seedOpenAIFunding(array $investors): void
     {
         $company = Company::where('slug', 'openai')->first();
-        if (!$company) return;
+        if (! $company) {
+            return;
+        }
 
         $rounds = [
             [
@@ -199,7 +203,9 @@ class FundingDataSeeder extends Seeder
     private function seedPerplexityFunding(array $investors): void
     {
         $company = Company::where('slug', 'perplexity')->first();
-        if (!$company) return;
+        if (! $company) {
+            return;
+        }
 
         $rounds = [
             [
@@ -251,7 +257,9 @@ class FundingDataSeeder extends Seeder
     private function seedStripeFunding(array $investors): void
     {
         $company = Company::where('slug', 'stripe')->first();
-        if (!$company) return;
+        if (! $company) {
+            return;
+        }
 
         $rounds = [
             [
@@ -322,7 +330,9 @@ class FundingDataSeeder extends Seeder
     private function seedSpaceXFunding(array $investors): void
     {
         $company = Company::where('slug', 'spacex')->first();
-        if (!$company) return;
+        if (! $company) {
+            return;
+        }
 
         $rounds = [
             [

--- a/database/seeders/FundingSourceUrlSeeder.php
+++ b/database/seeders/FundingSourceUrlSeeder.php
@@ -125,8 +125,9 @@ class FundingSourceUrlSeeder extends Seeder
 
         foreach ($sourceUrls as $companySlug => $rounds) {
             $company = Company::where('slug', $companySlug)->first();
-            if (!$company) {
+            if (! $company) {
                 $this->command->warn("Company not found: {$companySlug}");
+
                 continue;
             }
 
@@ -141,7 +142,7 @@ class FundingSourceUrlSeeder extends Seeder
 
                 // If announced_date prefix is specified, use it
                 if (isset($roundData['announced_date'])) {
-                    $query->where('announced_date', 'like', $roundData['announced_date'] . '%');
+                    $query->where('announced_date', 'like', $roundData['announced_date'].'%');
                 }
 
                 $round = $query->first();

--- a/database/seeders/HeadcountHistorySeeder.php
+++ b/database/seeders/HeadcountHistorySeeder.php
@@ -18,11 +18,13 @@ class HeadcountHistorySeeder extends Seeder
             $startYear = max($foundedYear, 2018);
             $endYear = 2025;
 
-            if ($startYear >= $endYear) continue;
+            if ($startYear >= $endYear) {
+                continue;
+            }
 
             // Determine current headcount: use existing or generate realistic one
             $current = $company->current_headcount;
-            if (!$current || $current <= 0) {
+            if (! $current || $current <= 0) {
                 // Generate based on company age and a seed
                 $age = 2025 - $foundedYear;
                 $seed = crc32($company->name);
@@ -35,7 +37,7 @@ class HeadcountHistorySeeder extends Seeder
             // Work backwards from current
             $annualCounts = [$current];
             for ($i = 1; $i <= $years; $i++) {
-                $factor = 1 + $growthRate * (0.7 + (crc32($company->name . $i) % 60) / 100);
+                $factor = 1 + $growthRate * (0.7 + (crc32($company->name.$i) % 60) / 100);
                 $prev = end($annualCounts) / $factor;
                 $annualCounts[] = max(1, (int) round($prev));
             }
@@ -46,14 +48,16 @@ class HeadcountHistorySeeder extends Seeder
             foreach ($annualCounts as $i => $count) {
                 $year = $startYear + $i;
                 foreach ([1, 4, 7, 10] as $month) {
-                    if ($year == $endYear && $month > 6) break;
+                    if ($year == $endYear && $month > 6) {
+                        break;
+                    }
                     $date = Carbon::create($year, $month, 1)->format('Y-m-d');
-                    $variance = 1 + ((crc32($date . $company->id) % 10) - 5) / 100;
+                    $variance = 1 + ((crc32($date.$company->id) % 10) - 5) / 100;
                     $history[] = ['date' => $date, 'headcount' => max(1, (int) round($count * $variance))];
                 }
             }
 
-            usort($history, fn($a, $b) => strcmp($a['date'], $b['date']));
+            usort($history, fn ($a, $b) => strcmp($a['date'], $b['date']));
 
             $company->update([
                 'headcount_history' => $history,

--- a/database/seeders/InvestorSeeder.php
+++ b/database/seeders/InvestorSeeder.php
@@ -2,8 +2,8 @@
 
 namespace Database\Seeders;
 
-use App\Models\Investor;
 use App\Models\FundingRound;
+use App\Models\Investor;
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Str;
 
@@ -48,7 +48,9 @@ class InvestorSeeder extends Seeder
         if ($rounds->count() && $allInvestors->count()) {
             foreach ($rounds as $round) {
                 // Skip if already has investors
-                if ($round->investors()->count()) continue;
+                if ($round->investors()->count()) {
+                    continue;
+                }
 
                 // Randomly assign 1-3 investors
                 $count = rand(1, 3);

--- a/database/seeders/MassiveBackfillSeeder.php
+++ b/database/seeders/MassiveBackfillSeeder.php
@@ -27,7 +27,7 @@ class MassiveBackfillSeeder extends Seeder
             }
         }
 
-        $this->command->info("MassiveBackfill - Created: {$created}, Updated: {$updated}, Total companies: " . Company::count());
+        $this->command->info("MassiveBackfill - Created: {$created}, Updated: {$updated}, Total companies: ".Company::count());
     }
 
     private function getCompanies(): array

--- a/database/seeders/MoreFundingDataSeeder.php
+++ b/database/seeders/MoreFundingDataSeeder.php
@@ -73,8 +73,12 @@ class MoreFundingDataSeeder extends Seeder
     private function seedDatabricksFunding(array $investors): void
     {
         $company = Company::where('slug', 'databricks')->first();
-        if (!$company) return;
-        if ($company->fundingRounds()->exists()) return;
+        if (! $company) {
+            return;
+        }
+        if ($company->fundingRounds()->exists()) {
+            return;
+        }
 
         $rounds = [
             [
@@ -151,8 +155,12 @@ class MoreFundingDataSeeder extends Seeder
     private function seedCanvaFunding(array $investors): void
     {
         $company = Company::where('slug', 'canva')->first();
-        if (!$company) return;
-        if ($company->fundingRounds()->exists()) return;
+        if (! $company) {
+            return;
+        }
+        if ($company->fundingRounds()->exists()) {
+            return;
+        }
 
         $rounds = [
             [
@@ -210,8 +218,12 @@ class MoreFundingDataSeeder extends Seeder
     private function seedFigmaFunding(array $investors): void
     {
         $company = Company::where('slug', 'figma')->first();
-        if (!$company) return;
-        if ($company->fundingRounds()->exists()) return;
+        if (! $company) {
+            return;
+        }
+        if ($company->fundingRounds()->exists()) {
+            return;
+        }
 
         $rounds = [
             [
@@ -268,8 +280,12 @@ class MoreFundingDataSeeder extends Seeder
     private function seedNotionFunding(array $investors): void
     {
         $company = Company::where('slug', 'notion')->first();
-        if (!$company) return;
-        if ($company->fundingRounds()->exists()) return;
+        if (! $company) {
+            return;
+        }
+        if ($company->fundingRounds()->exists()) {
+            return;
+        }
 
         $rounds = [
             [
@@ -314,8 +330,12 @@ class MoreFundingDataSeeder extends Seeder
     private function seedRipplingFunding(array $investors): void
     {
         $company = Company::where('slug', 'rippling')->first();
-        if (!$company) return;
-        if ($company->fundingRounds()->exists()) return;
+        if (! $company) {
+            return;
+        }
+        if ($company->fundingRounds()->exists()) {
+            return;
+        }
 
         $rounds = [
             [
@@ -380,7 +400,7 @@ class MoreFundingDataSeeder extends Seeder
             $roundData['company_id'] = $company->id;
 
             $round = FundingRound::firstOrCreate(
-                ["company_id" => $roundData["company_id"], "announced_date" => $roundData["announced_date"], "round_type" => $roundData["round_type"] ?? null],
+                ['company_id' => $roundData['company_id'], 'announced_date' => $roundData['announced_date'], 'round_type' => $roundData['round_type'] ?? null],
                 $roundData
             );
 

--- a/database/seeders/NewCompaniesSeeder.php
+++ b/database/seeders/NewCompaniesSeeder.php
@@ -51,6 +51,6 @@ class NewCompaniesSeeder extends Seeder
             );
         }
 
-        $this->command->info('Seeded ' . count($companies) . ' new companies.');
+        $this->command->info('Seeded '.count($companies).' new companies.');
     }
 }

--- a/database/seeders/PeopleSeeder.php
+++ b/database/seeders/PeopleSeeder.php
@@ -422,7 +422,7 @@ class PeopleSeeder extends Seeder
         $count = 0;
         foreach ($companyPeople as $slug => $people) {
             $company = Company::where('slug', $slug)->first();
-            if (!$company) {
+            if (! $company) {
                 continue;
             }
 

--- a/database/seeders/ProductHighlightsSeeder.php
+++ b/database/seeders/ProductHighlightsSeeder.php
@@ -806,7 +806,7 @@ class ProductHighlightsSeeder extends Seeder
 
         foreach ($highlights as $slug => $productHighlights) {
             $company = Company::where('slug', $slug)->first();
-            if ($company && !$company->product_highlights) {
+            if ($company && ! $company->product_highlights) {
                 $company->update([
                     'product_highlights' => $productHighlights,
                     'profile_refreshed_at' => now(),
@@ -814,6 +814,6 @@ class ProductHighlightsSeeder extends Seeder
             }
         }
 
-        $this->command->info('Updated ' . count($highlights) . ' companies with product highlights.');
+        $this->command->info('Updated '.count($highlights).' companies with product highlights.');
     }
 }

--- a/database/seeders/TechCrunchCompaniesSeeder.php
+++ b/database/seeders/TechCrunchCompaniesSeeder.php
@@ -644,6 +644,6 @@ class TechCrunchCompaniesSeeder extends Seeder
             );
         }
 
-        $this->command->info('Seeded ' . count($companies) . ' companies from TechCrunch headlines.');
+        $this->command->info('Seeded '.count($companies).' companies from TechCrunch headlines.');
     }
 }

--- a/database/seeders/UnicornBackfillSeeder.php
+++ b/database/seeders/UnicornBackfillSeeder.php
@@ -4,7 +4,6 @@ namespace Database\Seeders;
 
 use App\Models\Company;
 use Illuminate\Database\Seeder;
-use Illuminate\Support\Str;
 
 class UnicornBackfillSeeder extends Seeder
 {
@@ -2359,14 +2358,13 @@ class UnicornBackfillSeeder extends Seeder
                 ->orWhere('slug', $data['slug'])
                 ->first();
 
-            if (!$existing) {
+            if (! $existing) {
                 Company::create($data);
                 $count++;
             }
         }
 
         $this->command->info("Unicorn backfill complete: {$count} new companies added.");
-        $this->command->info("Total companies: " . Company::count());
+        $this->command->info('Total companies: '.Company::count());
     }
 }
-

--- a/database/seeders/YCBackfillSeeder.php
+++ b/database/seeders/YCBackfillSeeder.php
@@ -27,7 +27,7 @@ class YCBackfillSeeder extends Seeder
             }
         }
 
-        $this->command->info("YC Backfill - Created: {$created}, Updated: {$updated}, Total companies: " . Company::count());
+        $this->command->info("YC Backfill - Created: {$created}, Updated: {$updated}, Total companies: ".Company::count());
     }
 
     private function getCompanies(): array

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,16 +1,16 @@
 <?php
 
-use App\Http\Controllers\CompanyController;
-use App\Http\Controllers\SitemapController;
-use App\Http\Controllers\CompareController;
-use App\Http\Controllers\SubmissionController;
 use App\Http\Controllers\Admin\CompanyController as AdminCompanyController;
+use App\Http\Controllers\Admin\OssProjectController as AdminOssProjectController;
 use App\Http\Controllers\Admin\SubmissionController as AdminSubmissionController;
-use App\Http\Controllers\PersonController;
+use App\Http\Controllers\CompanyController;
+use App\Http\Controllers\CompareController;
 use App\Http\Controllers\InvestorController;
 use App\Http\Controllers\OpenSourceController;
+use App\Http\Controllers\PersonController;
 use App\Http\Controllers\ProfileController;
-use App\Http\Controllers\Admin\OssProjectController as AdminOssProjectController;
+use App\Http\Controllers\SitemapController;
+use App\Http\Controllers\SubmissionController;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/sitemap.xml', [SitemapController::class, 'index'])->name('sitemap');

--- a/tests/Feature/AdminTest.php
+++ b/tests/Feature/AdminTest.php
@@ -1,7 +1,5 @@
 <?php
 
-use App\Models\User;
-
 test('admin area requires auth', function () {
     $response = $this->get('/admin');
     $response->assertRedirect('/login');

--- a/tests/Feature/BulkImport/BaseBulkImporterTest.php
+++ b/tests/Feature/BulkImport/BaseBulkImporterTest.php
@@ -9,11 +9,24 @@ class BaseBulkImporterTest extends TestCase
 {
     public function test_status_mapping(): void
     {
-        $importer = new class extends BaseBulkImporter {
-            public function source(): string { return 'test'; }
+        $importer = new class extends BaseBulkImporter
+        {
+            public function source(): string
+            {
+                return 'test';
+            }
+
             public function import(array $options = []): void {}
-            public function publicMapStatus(string $s): string { return $this->mapStatus($s); }
-            public function publicExtractDomain(?string $u): ?string { return $this->extractDomain($u); }
+
+            public function publicMapStatus(string $s): string
+            {
+                return $this->mapStatus($s);
+            }
+
+            public function publicExtractDomain(?string $u): ?string
+            {
+                return $this->extractDomain($u);
+            }
         };
 
         $this->assertEquals('operating', $importer->publicMapStatus('Active'));
@@ -29,10 +42,19 @@ class BaseBulkImporterTest extends TestCase
 
     public function test_domain_extraction(): void
     {
-        $importer = new class extends BaseBulkImporter {
-            public function source(): string { return 'test'; }
+        $importer = new class extends BaseBulkImporter
+        {
+            public function source(): string
+            {
+                return 'test';
+            }
+
             public function import(array $options = []): void {}
-            public function publicExtractDomain(?string $u): ?string { return $this->extractDomain($u); }
+
+            public function publicExtractDomain(?string $u): ?string
+            {
+                return $this->extractDomain($u);
+            }
         };
 
         $this->assertEquals('stripe.com', $importer->publicExtractDomain('https://www.stripe.com'));

--- a/tests/Feature/BulkImport/CrunchbaseCsvImporterTest.php
+++ b/tests/Feature/BulkImport/CrunchbaseCsvImporterTest.php
@@ -3,7 +3,6 @@
 namespace Tests\Feature\BulkImport;
 
 use App\Models\Company;
-use App\Models\CompanyImport;
 use App\Services\BulkImport\CrunchbaseCsvImporter;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
@@ -14,7 +13,7 @@ class CrunchbaseCsvImporterTest extends TestCase
 
     public function test_imports_companies_from_csv(): void
     {
-        $importer = new CrunchbaseCsvImporter();
+        $importer = new CrunchbaseCsvImporter;
         $result = $importer->start([
             'file' => base_path('tests/fixtures/crunchbase_sample.csv'),
         ]);
@@ -31,7 +30,7 @@ class CrunchbaseCsvImporterTest extends TestCase
 
     public function test_maps_status_correctly(): void
     {
-        $importer = new CrunchbaseCsvImporter();
+        $importer = new CrunchbaseCsvImporter;
         $importer->start([
             'file' => base_path('tests/fixtures/crunchbase_sample.csv'),
         ]);
@@ -58,7 +57,7 @@ class CrunchbaseCsvImporterTest extends TestCase
             'website' => 'https://stripe.com',
         ]);
 
-        $importer = new CrunchbaseCsvImporter();
+        $importer = new CrunchbaseCsvImporter;
         $result = $importer->start([
             'file' => base_path('tests/fixtures/crunchbase_sample.csv'),
         ]);
@@ -73,7 +72,7 @@ class CrunchbaseCsvImporterTest extends TestCase
 
     public function test_skips_rows_without_name(): void
     {
-        $importer = new CrunchbaseCsvImporter();
+        $importer = new CrunchbaseCsvImporter;
         $result = $importer->start([
             'file' => base_path('tests/fixtures/crunchbase_sample.csv'),
         ]);
@@ -85,7 +84,7 @@ class CrunchbaseCsvImporterTest extends TestCase
 
     public function test_creates_import_log(): void
     {
-        $importer = new CrunchbaseCsvImporter();
+        $importer = new CrunchbaseCsvImporter;
         $result = $importer->start([
             'file' => base_path('tests/fixtures/crunchbase_sample.csv'),
         ]);

--- a/tests/Feature/CompareTest.php
+++ b/tests/Feature/CompareTest.php
@@ -7,9 +7,9 @@ test('compare page loads', function () {
     $user = User::factory()->create();
     $companies = Company::factory()->count(2)->create();
 
-    $response = $this->actingAs($user)->get('/compare?' . 
-        'companies[]=' . $companies[0]->id . 
-        '&companies[]=' . $companies[1]->id);
+    $response = $this->actingAs($user)->get('/compare?'.
+        'companies[]='.$companies[0]->id.
+        '&companies[]='.$companies[1]->id);
 
     $response->assertStatus(200);
 });

--- a/tests/Feature/DiscoveryServiceTest.php
+++ b/tests/Feature/DiscoveryServiceTest.php
@@ -1,8 +1,8 @@
 <?php
 
-use App\Services\Discovery\ProductHuntDiscoveryService;
-use App\Services\Discovery\GitHubOrgDiscoveryService;
 use App\Services\Discovery\CompaniesHouseService;
+use App\Services\Discovery\GitHubOrgDiscoveryService;
+use App\Services\Discovery\ProductHuntDiscoveryService;
 
 test('product hunt service throws without token', function () {
     $service = new ProductHuntDiscoveryService(null);

--- a/tests/Feature/SavedSearchTest.php
+++ b/tests/Feature/SavedSearchTest.php
@@ -1,7 +1,5 @@
 <?php
 
-use App\Models\User;
-
 test('saved search requires auth', function () {
     $response = $this->get('/saved-searches');
     $response->assertRedirect('/login');

--- a/tests/Unit/CompanyModelTest.php
+++ b/tests/Unit/CompanyModelTest.php
@@ -1,9 +1,6 @@
 <?php
 
 use App\Models\Company;
-use App\Models\FundingRound;
-use App\Models\Person;
-use App\Models\NewsMention;
 
 test('company has many funding rounds', function () {
     $company = Company::factory()->create();

--- a/tests/Unit/FundingRoundDeduplicationServiceTest.php
+++ b/tests/Unit/FundingRoundDeduplicationServiceTest.php
@@ -15,7 +15,8 @@ class FundingRoundDeduplicationServiceTest extends TestCase
     {
         parent::setUp();
         // Bypass config() call in constructor by creating and configuring manually
-        $this->service = new class extends FundingRoundDeduplicationService {
+        $this->service = new class extends FundingRoundDeduplicationService
+        {
             public function __construct()
             {
                 $this->dateTolerance = 30;
@@ -101,7 +102,7 @@ class FundingRoundDeduplicationServiceTest extends TestCase
      */
     private function makeFundingRound(string $date, ?float $amount): FundingRound
     {
-        $round = new FundingRound();
+        $round = new FundingRound;
         $round->announced_date = Carbon::parse($date);
         $round->amount = $amount;
 

--- a/tests/Unit/FundingRoundModelTest.php
+++ b/tests/Unit/FundingRoundModelTest.php
@@ -1,8 +1,7 @@
 <?php
 
-use App\Models\FundingRound;
 use App\Models\Company;
-use App\Models\Investor;
+use App\Models\FundingRound;
 
 test('funding round belongs to a company', function () {
     $company = Company::factory()->create();

--- a/tests/Unit/HeadcountSnapshotTest.php
+++ b/tests/Unit/HeadcountSnapshotTest.php
@@ -1,7 +1,7 @@
 <?php
 
-use App\Models\HeadcountSnapshot;
 use App\Models\Company;
+use App\Models\HeadcountSnapshot;
 
 test('headcount snapshot belongs to company', function () {
     $company = Company::factory()->create();

--- a/tests/Unit/NewsMentionTest.php
+++ b/tests/Unit/NewsMentionTest.php
@@ -1,7 +1,7 @@
 <?php
 
-use App\Models\NewsMention;
 use App\Models\Company;
+use App\Models\NewsMention;
 
 test('news mention belongs to company', function () {
     $company = Company::factory()->create();

--- a/tests/Unit/OpenSourceProjectModelTest.php
+++ b/tests/Unit/OpenSourceProjectModelTest.php
@@ -1,7 +1,7 @@
 <?php
 
-use App\Models\OpenSourceProject;
 use App\Models\Company;
+use App\Models\OpenSourceProject;
 
 test('open source project belongs to a company', function () {
     $company = Company::factory()->create();

--- a/tests/Unit/PersonModelTest.php
+++ b/tests/Unit/PersonModelTest.php
@@ -1,7 +1,7 @@
 <?php
 
-use App\Models\Person;
 use App\Models\Company;
+use App\Models\Person;
 
 test('person belongs to a company', function () {
     $company = Company::factory()->create();

--- a/tests/Unit/Services/FundingRoundDeduplicationServiceTest.php
+++ b/tests/Unit/Services/FundingRoundDeduplicationServiceTest.php
@@ -15,7 +15,8 @@ class FundingRoundDeduplicationServiceTest extends TestCase
     {
         parent::setUp();
         // Bypass config() in constructor by using anonymous subclass
-        $this->service = new class extends FundingRoundDeduplicationService {
+        $this->service = new class extends FundingRoundDeduplicationService
+        {
             public function __construct()
             {
                 $this->dateTolerance = 30;
@@ -23,17 +24,17 @@ class FundingRoundDeduplicationServiceTest extends TestCase
             }
 
             // Expose protected methods for direct testing
-            public function testAreDatesWithinTolerance($date1, string $date2): bool
+            public function test_are_dates_within_tolerance($date1, string $date2): bool
             {
                 return $this->areDatesWithinTolerance($date1, $date2);
             }
 
-            public function testAreAmountsWithinTolerance(float $a1, float $a2): bool
+            public function test_are_amounts_within_tolerance(float $a1, float $a2): bool
             {
                 return $this->areAmountsWithinTolerance($a1, $a2);
             }
 
-            public function testCalculateAmountDiffPercent(?float $a1, ?float $a2): ?float
+            public function test_calculate_amount_diff_percent(?float $a1, ?float $a2): ?float
             {
                 return $this->calculateAmountDiffPercent($a1, $a2);
             }
@@ -302,7 +303,7 @@ class FundingRoundDeduplicationServiceTest extends TestCase
 
     private function makeFundingRound(string $date, ?float $amount): FundingRound
     {
-        $round = new FundingRound();
+        $round = new FundingRound;
         $round->announced_date = Carbon::parse($date);
         $round->amount = $amount;
 

--- a/tests/Unit/TechCrunchServiceTest.php
+++ b/tests/Unit/TechCrunchServiceTest.php
@@ -12,7 +12,7 @@ class TechCrunchServiceTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->service = new TechCrunchService();
+        $this->service = new TechCrunchService;
     }
 
     public function test_extract_funding_info_with_million_amount(): void


### PR DESCRIPTION
Adds a seeder (`AsyncWorldwideSeeder`) with 58 companies from the [AsyncWorldwide.com](https://asyncworldwide.com) directory of 100% remote companies.

**Each company gets:**
- `import_source` = `asyncworldwide.com`
- `description` = `remote-first`
- `status` = `operating`

**The seeder is idempotent** — skips any company whose website URL already exists in the database.

**Already run locally:** 56 created, 2 skipped (Shogun & Storylane already existed).

**To run:**
```
php artisan db:seed --class=AsyncWorldwideSeeder
```

**Companies added:** Aha!, Appcues, Arbitrum, Arkency, Automattic, Awesome Motive, Buffer, Chili Piper, Constructor, Contra, Doist, DuckDuckGo, Float, FM, Ghost, GitLab, Gorilla Logic, Groove, Interaction Design Foundation, Kinsta, MailerLite, Levity, Lightdash, Literal Humans, Liveblocks, Mailbird, MeetEdgar, Modash, Namecheap, Okta, Omnipresent, Omniscient Digital, Oyster, Pitch, Plus AI, Remote, SafetyWing, Sanctuary Computer, ScaleMath, SimpleTexting, Smile.io, Sporty, Springworks, StackBlitz, Supabase, TestGorilla, Tether, The Shelf, tl;dv, Toggl, Tortuga, Whereby, Windsor.ai, YNAB, Zapier, Zyte